### PR TITLE
ci: add branch protection workflows and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @nozomiishii

--- a/.github/workflows/_actionlint.yaml
+++ b/.github/workflows/_actionlint.yaml
@@ -1,0 +1,36 @@
+name: Lint GitHub Actions workflows
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/**/*.ya?ml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check workflow files
+        # https://github.com/rhysd/actionlint
+        #
+        # To run locally, execute the following command:
+        # docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:latest
+        uses: docker://rhysd/actionlint:1.7.11@sha256:6f03470d0152251d7f07f7c4dc019dbe7024c72cd952f839544c7798843efa8f
+        with:
+          args: -color

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -1,0 +1,48 @@
+name: Pull Request title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          subjectPattern: ^[a-z][A-Za-z0-9 .,:;!?'"`@#$%&*()\[\]{}<>/\\|+=_~-]+(?<! )$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern.
+
+            Please follow these rules:
+            - Start with a lowercase English letter (a-z)
+            - Use only English letters, numbers, spaces, and allowed punctuation
+            - Do not end with a space
+            - Do not use emojis
+
+            Examples (valid):
+            - feat: add new API
+            - feat: fix bug #123
+            - feat: update action to v6 @user
+
+            Examples (invalid):
+            - feat: Capital start (upper case)
+            - feat: a  (too short)
+            - feat: trailing space  (trailing space)
+            - feat: emoji   (emoji not allowed)
+            - feat: 日本語 (english only allowed)

--- a/.github/workflows/_secretlint.yaml
+++ b/.github/workflows/_secretlint.yaml
@@ -1,0 +1,37 @@
+name: Secret scan
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+        # https://github.com/gitleaks/gitleaks-action
+        # gitleaksを使って過去のcommitで漏洩してないか確認できる
+        #
+        # docker run --rm -v "$(pwd):/workspace" -w /workspace zricethezav/gitleaks:latest detect --source=/workspace --verbose --redact --log-opts="--all --full-history"
+
+      - name: Secretlint
+        # https://github.com/secretlint/secretlint
+        #
+        # To run locally, execute the following command:
+        # docker run -v `pwd`:`pwd` -w `pwd` --rm -it secretlint/secretlint secretlint "**/*"
+        uses: docker://secretlint/secretlint:v11.3.1@sha256:53e0ad16c676e744c79e32655f58a5cdcdd3c6ea6ed5d77f232ef424670c9e06
+        with:
+          args: secretlint "**/*"


### PR DESCRIPTION
## Summary
- main ブランチの保護設定を追加（GitHub Ruleset で直接プッシュを禁止、PR 必須化）
- PR タイトルの semantic versioning バリデーション、GitHub Actions ワークフローの lint、シークレット漏洩スキャンのワークフローを追加
- CODEOWNERS で全ファイルのオーナーを @nozomiishii に設定

## Test plan
- [ ] PR タイトルバリデーションが正しく動作することを確認
- [ ] actionlint がワークフローファイルを正しく検証することを確認
- [ ] secretlint がシークレットスキャンを実行することを確認
- [ ] main ブランチへの直接プッシュが拒否されることを確認