### PR TITLE
chore: add Claude Code entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 **/.claude/settings.local.json
 **/CLAUDE.local.md
 **/.claude/worktrees/
+**/.claude/debug/
 
 # Logs
 *.log


### PR DESCRIPTION
## Summary
- `.gitignore` に Claude Code 関連のエントリを追加
  - `.claude/settings.local.json` (個人用設定)
  - `CLAUDE.local.md` (個人用指示)
  - `.claude/worktrees/` (一時ワークツリー)
  - `.claude/debug/` (デバッグログ)

## Test plan
- [ ] `.gitignore` に追加されたパターンが正しく機能することを確認