### PR TITLE
fix(ci): add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## 概要

CI ワークフローに `workflow_dispatch` トリガーを追加。

Release Please が `GITHUB_TOKEN` で作成した PR では、GitHub の仕様により他のワークフローが自動トリガーされない。`workflow_dispatch` を追加することで、手動で CI を実行できるようにする。
