### PR TITLE
ci: add paths-filter for actionlint and use GitHub App token for release-please

### DIFF
--- a/.github/workflows/_actionlint.yaml
+++ b/.github/workflows/_actionlint.yaml
@@ -6,8 +6,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - '.github/**/*.ya?ml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +24,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Check for changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3
+        id: changes
+        with:
+          filters: |
+            workflows:
+              - '.github/**/*.yaml'
+
       - name: Check workflow files
+        if: steps.changes.outputs.workflows == 'true'
         # https://github.com/rhysd/actionlint
         #
         # To run locally, execute the following command:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -21,11 +24,28 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Load secrets from 1Password
+        id: secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          APP_ID: op://github-app/nozomiishii-release/username
+          APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        with:
+          app-id: ${{ steps.secrets.outputs.APP_ID }}
+          private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+
+      - name: Run release-please
         id: release
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           config-file: .github/.release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}
 
   upload-assets:
     needs: release-please


### PR DESCRIPTION
## Summary

- `_actionlint.yaml` の paths トリガーを `dorny/paths-filter` に置き換え、required status checks 対応
- GitHub App (`nozomiishii-release`) の installation access token を Release Please に導入
- `release-please-action` を SHA ピン留めに変更
- トップレベルに `permissions: {}` を追加（最小権限）

## 背景

Release Please が `GITHUB_TOKEN` で作成した PR は CI がトリガーされない GitHub の仕様を回避するため。
また `actionlint` を required status checks に追加するため paths フィルタを移行。

## マージ後の手動作業

- ruleset に `actionlint` を追加

## Test plan

- [ ] PR の CI が全て成功することを確認
- [ ] マージ後、Release Please が `nozomiishii-release[bot]` として PR を作成することを確認
- [ ] その PR で CI が実行されることを確認