### PR TITLE
ci: add homebrew cask auto-update on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -197,29 +197,43 @@ jobs:
           owner: nozomiishii
           repositories: homebrew-tap
 
-      - name: Update Homebrew cask
+      - name: Download release asset
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: |
+          gh release download "$TAG_NAME" \
+            --repo nozomiishii/Brooklyn \
+            --pattern "Brooklyn.saver.zip" \
+            --dir /tmp
+
+      - name: Calculate sha256
+        id: hash
+        run: echo "sha256=$(sha256sum /tmp/Brooklyn.saver.zip | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Clone homebrew-tap
+        run: git clone https://github.com/nozomiishii/homebrew-tap.git /tmp/homebrew-tap
+
+      - name: Update cask
+        working-directory: /tmp/homebrew-tap
+        env:
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+          SHA256: ${{ steps.hash.outputs.sha256 }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          sed -i "s/version \".*\"/version \"$VERSION\"/" Casks/brooklyn.rb
+          sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/brooklyn.rb
+
+      - name: Commit and push
+        working-directory: /tmp/homebrew-tap
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
         run: |
           VERSION="${TAG_NAME#v}"
-
-          # Download release asset and calculate sha256
-          gh release download "$TAG_NAME" \
-            --repo nozomiishii/Brooklyn \
-            --pattern "Brooklyn.saver.zip" \
-            --dir /tmp
-          SHA256=$(shasum -a 256 /tmp/Brooklyn.saver.zip | awk '{print $1}')
-
-          # Clone homebrew-tap and update cask
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/nozomiishii/homebrew-tap.git" /tmp/homebrew-tap
-          cd /tmp/homebrew-tap
-
-          sed -i "s/version \".*\"/version \"$VERSION\"/" Casks/brooklyn.rb
-          sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" Casks/brooklyn.rb
-
           git config user.name "nozomiishii-release[bot]"
           git config user.email "nozomiishii-release[bot]@users.noreply.github.com"
           git add Casks/brooklyn.rb
           git commit -m "brooklyn $VERSION"
-          git push origin main
+          AUTH=$(echo -n "x-access-token:${GH_TOKEN}" | base64)
+          git -c "http.extraheader=Authorization: Basic ${AUTH}" push origin main


### PR DESCRIPTION
## Summary
- リリース時に homebrew-tap の `Casks/brooklyn.rb` を自動更新する `homebrew-update` ジョブを `release.yaml` に追加
- `upload-assets` 完了後に Brooklyn.saver.zip の sha256 を計算し、cask の version と sha256 を更新してコミット
- git-harvest の Formula 自動更新と同じパターン（1Password + GitHub App token）

## Test plan
- [ ] 次回リリース時に `homebrew-update` ジョブが正常に実行されることを確認
- [ ] homebrew-tap の `Casks/brooklyn.rb` が新バージョンに更新されることを確認
- [ ] `brew install nozomiishii/tap/brooklyn` でインストールできることを確認