### PR TITLE
fix(docs): correct CHANGELOG entries for v0.1.2, v0.1.3, v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,7 @@
 
 ## [0.1.5](https://github.com/nozomiishii/Brooklyn/compare/v0.1.4...v0.1.5) (2026-04-02)
 
-
-### Features
-
-* add CI/CD pipeline with Release Please automation ([#1](https://github.com/nozomiishii/Brooklyn/issues/1)) ([358527f](https://github.com/nozomiishii/Brooklyn/commit/358527f6793fc8d95014e0ec3ddaeb940120e6c5))
-
-
-### Bug Fixes
-
-* **ci:** add workflow_dispatch trigger to CI workflow ([#7](https://github.com/nozomiishii/Brooklyn/issues/7)) ([f0e9d58](https://github.com/nozomiishii/Brooklyn/commit/f0e9d5894af38c1cbcb79b505c5357cf5a27eda7))
-* **ci:** use draft release to support immutable release uploads ([#12](https://github.com/nozomiishii/Brooklyn/issues/12)) ([269b5d0](https://github.com/nozomiishii/Brooklyn/commit/269b5d0c605c1538299ec42434261b8723ac8886))
-* **ci:** use GitHub App token for release asset upload ([#10](https://github.com/nozomiishii/Brooklyn/issues/10)) ([9abe83d](https://github.com/nozomiishii/Brooklyn/commit/9abe83def7b3bbeced5419a73407b40337017954))
+No notable changes.
 
 ## [0.1.4](https://github.com/nozomiishii/Brooklyn/compare/v0.1.3...v0.1.4) (2026-04-02)
 
@@ -28,19 +18,14 @@
 
 * **ci:** use draft release to support immutable release uploads ([#12](https://github.com/nozomiishii/Brooklyn/issues/12)) ([269b5d0](https://github.com/nozomiishii/Brooklyn/commit/269b5d0c605c1538299ec42434261b8723ac8886))
 
-## [0.1.3](https://github.com/nozomiishii/Brooklyn/compare/v0.1.2...v0.1.3) (2026-04-02)
+## [0.1.3](https://github.com/nozomiishii/Brooklyn/compare/v0.1.2...v0.1.3) (2026-04-02) [YANKED]
 
 
 ### Bug Fixes
 
 * **ci:** use GitHub App token for release asset upload ([#10](https://github.com/nozomiishii/Brooklyn/issues/10)) ([9abe83d](https://github.com/nozomiishii/Brooklyn/commit/9abe83def7b3bbeced5419a73407b40337017954))
 
-## [0.1.2](https://github.com/nozomiishii/Brooklyn/compare/v0.1.1...v0.1.2) (2026-04-02)
-
-
-### Features
-
-* add CI/CD pipeline with Release Please automation ([#1](https://github.com/nozomiishii/Brooklyn/issues/1)) ([358527f](https://github.com/nozomiishii/Brooklyn/commit/358527f6793fc8d95014e0ec3ddaeb940120e6c5))
+## [0.1.2](https://github.com/nozomiishii/Brooklyn/compare/v0.1.1...v0.1.2) (2026-04-02) [YANKED]
 
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

- v0.1.2, v0.1.3 に `[YANKED]` マークを追加（アセットなしの壊れたリリース）
- v0.1.2 から v0.1.1 以前のエントリ (#1) を削除
- v0.1.5 の重複エントリ (#1, #7, #10, #12) を削除し「No notable changes.」に置換

## 背景

release-please-action v4 の `draft: true` バグにより、前回リリースを認識できず過去コミットが CHANGELOG に重複して含まれていた。GitHub Release Notes は `gh release edit` で既に修正済み。

## Test plan

- [ ] GitHub Releases ページで v0.1.2, v0.1.3, v0.1.5 のノートが正しいことを確認
- [ ] CHANGELOG.md の各エントリが実際のコミット履歴と一致することを確認