### PR TITLE
chore(ci): simplify commit types to feat, fix, and chore

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -7,6 +7,11 @@
   "draft": true,
   "force-tag-creation": true,
   "pull-request-title-pattern": "chore: release ${version}",
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "section": "Miscellaneous" }
+  ],
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary

- `changelog-sections` を feat / fix / chore の3タイプに簡素化
- 全タイプを Release Notes に表示（`hidden` なし）
- コミットの type 分類ミスによるリリース漏れを構造的に防止

## 背景

Conventional Commits 仕様が定義しているのは `feat`, `fix`, `BREAKING CHANGE` の3つだけ。`docs`, `perf`, `refactor` 等は Angular 由来の慣習であり仕様の一部ではない。type が多いほど分類の判断に迷いが生じ、リリースに含めたかった変更が漏れるリスクがある。

判断基準を2つに絞る:
1. **feat / fix / chore のどれか？** — 新機能、バグ修正、それ以外
2. **破壊的か？** — `!` を付けるか（`feat!:`, `fix!:`, `chore!:`）

## Test plan

- [ ] 次のリリースで feat, fix, chore 全ての type が Release Notes に表示されること
- [ ] `chore` コミットのみでも release PR が作成されること