### PR TITLE
chore(ci): restrict PR title types to feat, fix, and chore

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -25,6 +25,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          types: |
+            feat
+            fix
+            chore
           subjectPattern: ^[a-z][A-Za-z0-9 .,:;!?'"`@#$%&*()\[\]{}<>/\\|+=_~-]+(?<! )$
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" didn't match the configured pattern.


### PR DESCRIPTION
## Summary

- PR タイトルの許可タイプを feat / fix / chore の3つに制限
- `action-semantic-pull-request` の `types` 設定を追加

## 背景

Conventional Commits 仕様が定義しているのは feat, fix, BREAKING CHANGE の3つだけ。commitlint-config の type-enum 制限（nozomiishii/configs#2027）と合わせて、全プロジェクトでコミットタイプを統一する。

## Test plan

- [ ] `feat: ...` の PR タイトルが通ること
- [ ] `fix: ...` の PR タイトルが通ること
- [ ] `chore: ...` の PR タイトルが通ること
- [ ] `docs: ...` の PR タイトルが拒否されること