### PR TITLE
fix(ci): add concurrency group to prevent release workflow race condition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,11 @@ defaults:
   run:
     shell: bash
 
+# 同時実行を防止し、release-pr が未完了のリリースを参照する競合を回避する
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 # デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
 permissions: {}
 


### PR DESCRIPTION
## Summary

- release ワークフローに concurrency group を追加し、同時実行を防止

## 背景

複数の PR を短時間で連続マージすると、release ワークフローが同時に複数実行される。先行するワークフローの `release-pr` ジョブが、後続ワークフローの `create-draft-release` + `upload-assets` が完了する前に走り、前回リリースを見つけられず全過去コミットが changelog に含まれる。

`cancel-in-progress: false` で先行ワークフローの完了を待機させることで、release の publish と次の release-pr 計算の順序を保証する。

## Test plan

- [ ] 連続で PR をマージしても、release PR に過去コミットが重複しないこと