### PR TITLE
fix: use MARKETING_VERSION as single source of truth for bundle version

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -17,9 +17,8 @@
       "release-type": "simple",
       "extra-files": [
         {
-          "type": "xml",
-          "path": "Brooklyn/Info.plist",
-          "xpath": "//dict/key[text()='CFBundleShortVersionString']/following-sibling::string[1]"
+          "type": "generic",
+          "path": "project.yaml"
         }
       ]
     }

--- a/Brooklyn/Info.plist
+++ b/Brooklyn/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.9</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Canvas/Info.plist
+++ b/Canvas/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSMainStoryboardFile</key>

--- a/project.yaml
+++ b/project.yaml
@@ -11,6 +11,7 @@ settings:
     SWIFT_VERSION: "6"
     MACOSX_DEPLOYMENT_TARGET: "26.0"
     ARCHS: arm64
+    MARKETING_VERSION: "0.1.9" # x-release-please-version
 
 targets:
   Brooklyn:


### PR DESCRIPTION
## Summary

Xcode 26 が `MARKETING_VERSION` 未設定時にデフォルト `1.0.0` を適用し、Info.plist のハードコード値を上書きしていた。これにより `.saver` のバージョンが常に `1.0.0` になり、Homebrew cask (`version "0.1.9"`) との不整合が発生。

- `project.yaml` のプロジェクトレベル設定に `MARKETING_VERSION` を追加し、唯一のバージョンソースに
- `Brooklyn/Info.plist` と `Canvas/Info.plist` を `$(MARKETING_VERSION)` プレースホルダーに変更
- Release Please の updater を XML xpath から generic (`# x-release-please-version` マーカー) に切替

## Test plan

- [x] `make generate` → pbxproj に `MARKETING_VERSION = 0.1.9` が反映されることを確認
- [x] `make build` → `defaults read` で `CFBundleShortVersionString = 0.1.9` を確認
- [x] `make test` → 全テストパス
- [ ] CI が通ることを確認