### PR TITLE
fix: add macOS 26 Tahoe compatibility for screen saver

### DIFF
--- a/Brooklyn/Sources/BrooklynView.swift
+++ b/Brooklyn/Sources/BrooklynView.swift
@@ -3,14 +3,16 @@ import ScreenSaver
 
 /// The main screen saver view that plays Brooklyn animations.
 ///
-/// Handles the macOS Sonoma+ bugs:
+/// Handles macOS Sonoma+ / Tahoe bugs:
 /// - `stopAnimation()` not being called → listens for `com.apple.screensaver.willstop`
 /// - `isPreview` always returning true → frame size heuristic
+/// - Ghost instances with zero frame on Tahoe → early return in init
 final class BrooklynView: ScreenSaverView {
     private var manager: BrooklynManager?
     private var player: LoopPlayer?
     private var playerLayer: AVPlayerLayer?
     private var configureSheetController: ConfigureSheetController?
+    private var isAnimationStarted = false
     nonisolated(unsafe) private var willStopObserver: NSObjectProtocol?
 
     // MARK: - Initialization
@@ -18,6 +20,13 @@ final class BrooklynView: ScreenSaverView {
     override init?(frame: NSRect, isPreview: Bool) {
         let actualIsPreview = frame.width < 400 && frame.height < 300
         super.init(frame: frame, isPreview: actualIsPreview)
+
+        // macOS 26 Tahoe: legacyScreenSaver.appex creates ghost instances with zero frame.
+        // Skip setup entirely to avoid wasting resources.
+        if frame == .zero {
+            return
+        }
+
         setup()
     }
 
@@ -70,8 +79,13 @@ final class BrooklynView: ScreenSaverView {
     }
 
     private func cleanUp() {
+        if isAnimationStarted {
+            stopAnimation()
+        }
         player?.tearDown()
+        player = nil
         playerLayer?.removeFromSuperlayer()
+        playerLayer = nil
         if let observer = willStopObserver {
             DistributedNotificationCenter.default().removeObserver(observer)
             willStopObserver = nil
@@ -81,17 +95,26 @@ final class BrooklynView: ScreenSaverView {
     // MARK: - ScreenSaverView Overrides
 
     override func startAnimation() {
+        guard !isAnimationStarted, player != nil else { return }
         super.startAnimation()
+        isAnimationStarted = true
         player?.play()
     }
 
     override func stopAnimation() {
+        guard isAnimationStarted else { return }
         super.stopAnimation()
+        isAnimationStarted = false
         player?.pause()
     }
 
     override func resize(withOldSuperviewSize oldSize: NSSize) {
         super.resize(withOldSuperviewSize: oldSize)
+        playerLayer?.frame = bounds
+    }
+
+    override func layout() {
+        super.layout()
         playerLayer?.frame = bounds
     }
 

--- a/Canvas/AppDelegate.swift
+++ b/Canvas/AppDelegate.swift
@@ -2,12 +2,14 @@ import AppKit
 import ScreenSaver
 
 /// Debug application that hosts the BrooklynView without installing the screen saver.
-@main
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private var window: NSWindow?
     private var saverView: BrooklynView?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate()
+
         let screenFrame = NSScreen.main?.frame ?? NSRect(x: 0, y: 0, width: 1920, height: 1080)
         let windowFrame = NSRect(
             x: screenFrame.midX - 640,

--- a/Canvas/Info.plist
+++ b/Canvas/Info.plist
@@ -18,8 +18,6 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>NSMainStoryboardFile</key>
-	<string></string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/Canvas/main.swift
+++ b/Canvas/main.swift
@@ -1,0 +1,8 @@
+import AppKit
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let delegate = AppDelegate()
+app.delegate = delegate
+app.activate()
+app.run()


### PR DESCRIPTION
## Summary
- macOS 26 Tahoe の `legacyScreenSaver.appex` がゼロフレーム `(0,0,0,0)` でゴーストインスタンスを生成する問題に対応し、早期リターンでリソース浪費を防止
- `startAnimation`/`stopAnimation` の重複呼び出しガードと player nil チェックを追加
- `layout()` オーバーライドで AVPlayerLayer のフレームを確実に同期（マルチディスプレイでの表示ずれ修正）
- Canvas デバッグアプリを macOS 26 対応（`@main` → `main.swift` で明示的に NSApplication セットアップ）

## Test plan
- [ ] `make test` — 26 テスト全パス確認済み
- [ ] `make install` → システム設定でスクリーンセーバーのプレビューが表示されること
- [ ] マルチディスプレイ環境で両画面に正しく表示されること
- [ ] `make generate && open Brooklyn.xcodeproj` → Canvas スキームでウィンドウが表示され動画再生されること