### PR TITLE
fix: remove deprecated -kill flag from lsregister in make reset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ reset:
 	-killall "System Settings" 2>/dev/null
 	rm -rf ~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/*
 	rm -f ~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/ByHost/dev.nozomiishii.brooklyn.*.plist
-	/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain user
+	-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -r -domain local -domain user
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
## Summary
- macOS 26 Tahoe で `lsregister -kill` が廃止されたため、`make reset` からフラグを削除

## Test plan
- [ ] `make reset` がエラーなく完了すること