### PR TITLE
fix: initialize BrooklynManager before zero-frame guard for ghost instances

### DIFF
--- a/Brooklyn/Sources/BrooklynView.swift
+++ b/Brooklyn/Sources/BrooklynView.swift
@@ -21,30 +21,26 @@ final class BrooklynView: ScreenSaverView {
         let actualIsPreview = frame.width < 400 && frame.height < 300
         super.init(frame: frame, isPreview: actualIsPreview)
 
+        // Always create manager so configureSheet works even for ghost instances.
+        manager = BrooklynManager(bundle: Bundle(for: BrooklynView.self))
+
         // macOS 26 Tahoe: legacyScreenSaver.appex creates ghost instances with zero frame.
-        // Skip setup entirely to avoid wasting resources.
+        // Skip visual/player setup to avoid wasting resources.
         if frame == .zero {
             return
         }
 
-        setup()
+        wantsLayer = true
+        layer?.backgroundColor = NSColor(red: 0.0, green: 0.01, blue: 0.0, alpha: 1.0).cgColor
+        animationTimeInterval = 1.0 / 30.0
+
+        setupPlayer()
+        observeLifecycle()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) is not supported")
-    }
-
-    private func setup() {
-        wantsLayer = true
-        layer?.backgroundColor = NSColor(red: 0.0, green: 0.01, blue: 0.0, alpha: 1.0).cgColor
-        animationTimeInterval = 1.0 / 30.0
-
-        let bundle = Bundle(for: BrooklynView.self)
-        manager = BrooklynManager(bundle: bundle)
-
-        setupPlayer()
-        observeLifecycle()
     }
 
     private func setupPlayer() {

--- a/BrooklynTests/BrooklynViewTests.swift
+++ b/BrooklynTests/BrooklynViewTests.swift
@@ -143,4 +143,13 @@ final class BrooklynViewTests: XCTestCase {
 
         XCTAssertTrue(view.hasConfigureSheet, "BrooklynView must report having a configure sheet")
     }
+
+    /// Regression: macOS 26 Tahoe ghost instances (frame .zero) must still provide
+    /// a configure sheet so the Options button works in System Settings.
+    func testGhostInstanceProvidesConfigureSheet() {
+        let view = BrooklynView(frame: .zero, isPreview: true)
+        XCTAssertNotNil(view, "Ghost view should be created")
+        XCTAssertTrue(view!.hasConfigureSheet)
+        XCTAssertNotNil(view!.configureSheet, "Ghost instance must still provide a configure sheet")
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ lint:
 install: build
 	cp -R build/Build/Products/Release/Brooklyn.saver ~/Library/Screen\ Savers/
 	codesign --force --sign - ~/Library/Screen\ Savers/Brooklyn.saver
+	-killall legacyScreenSaver 2>/dev/null
 
 # Uninstall the screen saver
 uninstall:


### PR DESCRIPTION
## Summary

macOS 26 Tahoe の `legacyScreenSaver.appex` が生成するゴーストインスタンス（frame `.zero`）で `configureSheet` が `nil` を返し、System Settings の Options ボタンが機能しない問題を修正。

- `BrooklynManager` の生成をゼロフレームガードの前に移動し、ゴーストインスタンスでも有効な configure sheet を提供
- `make install` に `killall legacyScreenSaver` を追加し、インストール後に appex が新バイナリを確実に再読み込み
- ゴーストインスタンスで `configureSheet` が非 nil を返すリグレッションテストを追加

## Test plan

- [x] `make test` — 全 39 テストパス（新規テスト含む）
- [ ] `make install` → System Settings → Brooklyn 選択 → Options ボタンで設定シートが開くことを確認
- [ ] Preview が正常に動作することを確認
- [ ] スクリーンセーバー本体が正常に再生されることを確認