### PR TITLE
chore: update README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,7 @@ brew uninstall nozomiishii/tap/brooklyn
 Brooklyn はこれらの素晴らしいプロジェクトなしには存在しませんでした。Screen Saver中のMacも美しいです。
 
 - [Brooklyn by Pedro Carrasco](https://github.com/pedrommcarrasco/Brooklyn) オリジナルの Brooklyn スクリーンセーバー。伝説的です。
-- [Apple の Brooklyn イベント (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) 僕がAppleに入社した時Zのイベント。同時期にあった[Apple 渋谷のリニューアルオープンビデオ](https://www.youtube.com/watch?v=30rXa448tGA)とも重なって[ANIMAL HACKさんのFranny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR)がずっと脳内再生されてます。思い出深いです。しみじみです。
+- [Apple の Brooklyn イベント (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) 僕がAppleに入社した時期のイベント。同時期にあった[Apple 渋谷のリニューアルオープンビデオ](https://www.youtube.com/watch?v=30rXa448tGA)とも重なって[ANIMAL HACKさんのFranny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR)がずっと脳内再生されてます。思い出深いです。しみじみです。
 
 ## License
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -25,27 +25,17 @@
 brew install nozomiishii/tap/brooklyn
 ```
 
-### ソースからビルド
-
-```sh
-make install
-```
-
-`.saver` バンドルをビルドし、`~/Library/Screen Savers/` にコピーして署名します。
-
 ## Uninstall
 
 ```sh
 brew uninstall nozomiishii/tap/brooklyn
 ```
 
-ソースからビルドした場合は `make uninstall` を実行してください。または **システム設定 > スクリーンセーバー** から手動で削除できます。
-
 ## Customization
 
 **システム設定 > スクリーンセーバー > Brooklyn** を開いてオプションボタンをクリックします。
 
-- **Customize OFF（デフォルト）**: 全 75 アニメーションがランダム順で再生。オリジナルの Apple ロゴが最初に流れます
+- **Customize OFF（デフォルト）**: オリジナルの Apple ロゴアニメーションを最初に再生したあと、残りの 74 種をシャッフルして無限ループします
 - **Customize ON**: お気に入りのアニメーションを選んで、ループ回数やシャッフル順を設定できます
 
 ## 謝辞

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,7 @@ brew uninstall nozomiishii/tap/brooklyn
 Brooklyn はこれらの素晴らしいプロジェクトなしには存在しませんでした。Screen Saver中のMacも美しいです。
 
 - [Brooklyn by Pedro Carrasco](https://github.com/pedrommcarrasco/Brooklyn) オリジナルの Brooklyn スクリーンセーバー。伝説的です。
-- [Apple の Brooklyn イベント (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) 僕がAppleに入社した時期のイベント。同時期にあった[Apple 渋谷のリニューアルオープンビデオ](https://www.youtube.com/watch?v=30rXa448tGA)とも重なって[ANIMAL HACKさんのFranny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR)がずっと脳内再生されてます。思い出深いです。しみじみです。
+- [Apple の Brooklyn イベント (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) 同時期にあった[Apple 渋谷のリニューアルオープンビデオ](https://www.youtube.com/watch?v=30rXa448tGA)とも重なって[ANIMAL HACKさんのFranny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR)がずっと脳内再生されてます。思い出深いです。しみじみです。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Open **System Settings > Screen Saver > Brooklyn** and click the options button.
 Brooklyn wouldn't exist without these amazing projects. Your Mac looks beautiful even during screen saver time.
 
 - [Brooklyn by Pedro Carrasco](https://github.com/pedrommcarrasco/Brooklyn) The original Brooklyn screen saver. Truly legendary.
-- [Apple's Brooklyn event (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) The event around when I joined Apple. It overlaps in my memory with the [Apple Shibuya reopening video](https://www.youtube.com/watch?v=30rXa448tGA) from the same time, and [ANIMAL HACK's Franny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR) keeps playing in my head. Full of memories. Deeply nostalgic.
+- [Apple's Brooklyn event (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) It overlaps in my memory with the [Apple Shibuya reopening video](https://www.youtube.com/watch?v=30rXa448tGA) from the same time, and [ANIMAL HACK's Franny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR) keeps playing in my head. Full of memories. Deeply nostalgic.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,27 +25,17 @@ A reimplementation of [Pedro Carrasco's original Brooklyn](https://github.com/pe
 brew install nozomiishii/tap/brooklyn
 ```
 
-### Build from source
-
-```sh
-make install
-```
-
-This builds the `.saver` bundle, copies it to `~/Library/Screen Savers/`, and signs it.
-
 ## Uninstall
 
 ```sh
 brew uninstall nozomiishii/tap/brooklyn
 ```
 
-If you built from source, run `make uninstall` instead. Or remove it manually from **System Settings > Screen Saver**.
-
 ## Customization
 
 Open **System Settings > Screen Saver > Brooklyn** and click the options button.
 
-- **Customize OFF (default)**: All 75 animations play in random order, starting with the original Apple logo
+- **Customize OFF (default)**: Plays the original Apple logo animation first, then shuffles the remaining 74 and loops endlessly
 - **Customize ON**: Pick your favorite animations and control the loop count and shuffle order
 
 ## Acknowledgments
@@ -53,7 +43,7 @@ Open **System Settings > Screen Saver > Brooklyn** and click the options button.
 Brooklyn wouldn't exist without these amazing projects. Your Mac looks beautiful even during screen saver time.
 
 - [Brooklyn by Pedro Carrasco](https://github.com/pedrommcarrasco/Brooklyn) The original Brooklyn screen saver. Truly legendary.
-- [Apple's Brooklyn event (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) The event around when I joined Apple. It overlaps in my memory with the [Apple Shibuya reopening video](https://www.youtube.com/watch?v=30rXa448tGA) from the same time, and [ANIMAL HACK's Franny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR) keeps playing in my head. Deeply nostalgic.
+- [Apple's Brooklyn event (2018)](https://www.apple.com/newsroom/2018/10/highlights-from-apples-keynote-event/) The event around when I joined Apple. It overlaps in my memory with the [Apple Shibuya reopening video](https://www.youtube.com/watch?v=30rXa448tGA) from the same time, and [ANIMAL HACK's Franny](https://open.spotify.com/track/31a06sRIW6qMMfONkhl9yR) keeps playing in my head. Full of memories. Deeply nostalgic.
 
 ## License
 


### PR DESCRIPTION
## Summary

- README.ja.md を正として README.md の内容を同期
- Build from source セクションと Uninstall の追加テキストを削除
- Customize OFF の説明を実際の再生ロジック（オリジナル先頭 → 残り74種シャッフル → 無限ループ）に修正
- 謝辞の「思い出深いです。しみじみです。」に対応する英訳を追加

## Test plan

- [ ] README.md と README.ja.md のセクション構造が一致していることを確認
- [ ] リンクが正しく機能すること