### PR TITLE
chore: add SwiftLint and SwiftFormat with Mint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,27 @@ defaults:
 jobs:
   lint:
     runs-on: macos-26
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install SwiftLint and SwiftFormat
-        run: brew install swiftlint swiftformat
+      - name: Install Mint
+        run: brew install mint
+
+      - name: Cache Mint packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ~/.mint
+          key: mint-${{ runner.os }}-${{ hashFiles('Mintfile') }}
+          restore-keys: mint-${{ runner.os }}-
+
+      - name: Bootstrap tools
+        run: mint bootstrap
 
       - name: Lint
-        run: |
-          swiftlint --strict --config .swiftlint.yaml
-          swiftformat --lint .
+        run: make lint
 
   build-and-test:
     runs-on: macos-26

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,23 @@ defaults:
     shell: bash
 
 jobs:
+  lint:
+    runs-on: macos-26
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Mint
+        run: brew install mint
+
+      - name: Bootstrap tools
+        run: mint bootstrap
+
+      - name: Lint
+        run: make lint
+
   build-and-test:
     runs-on: macos-26
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,20 +17,19 @@ defaults:
 jobs:
   lint:
     runs-on: macos-26
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Mint
-        run: brew install mint
-
-      - name: Bootstrap tools
-        run: mint bootstrap
+      - name: Install SwiftLint and SwiftFormat
+        run: brew install swiftlint swiftformat
 
       - name: Lint
-        run: make lint
+        run: |
+          swiftlint --strict --config .swiftlint.yaml
+          swiftformat --lint .
 
   build-and-test:
     runs-on: macos-26

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,9 @@ jobs:
       - name: Lint
         run: make lint
 
+      - name: Format check
+        run: make format-check
+
   build-and-test:
     runs-on: macos-26
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ build/
 .build/
 .swiftpm/
 
+# SwiftLint
+.swiftlint-cache/
+
 # Claude Code
 **/.claude/settings.local.json
 **/CLAUDE.local.md

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,2 @@
+--swiftversion 6.0
+--exclude build,.claude,Brooklyn.xcodeproj

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,2 +1,1 @@
 --swiftversion 6.0
---exclude build,.claude,Brooklyn.xcodeproj

--- a/.swiftlint.yaml
+++ b/.swiftlint.yaml
@@ -1,0 +1,9 @@
+excluded:
+  - build
+  - Brooklyn.xcodeproj
+  - .claude
+
+disabled_rules:
+  - trailing_comma # SwiftFormat が trailing comma を管理
+
+line_length: 200

--- a/.swiftlint.yaml
+++ b/.swiftlint.yaml
@@ -1,8 +1,3 @@
-excluded:
-  - build
-  - Brooklyn.xcodeproj
-  - .claude
-
 disabled_rules:
   - trailing_comma # SwiftFormat が trailing comma を管理
 

--- a/Brooklyn/ConfigureSheet/ConfigureSheet.swift
+++ b/Brooklyn/ConfigureSheet/ConfigureSheet.swift
@@ -5,7 +5,7 @@ struct ConfigureSheet: View {
     @ObservedObject private var viewModel: ConfigureSheetViewModel
 
     init(manager: BrooklynManager) {
-        self._viewModel = ObservedObject(wrappedValue: ConfigureSheetViewModel(manager: manager))
+        _viewModel = ObservedObject(wrappedValue: ConfigureSheetViewModel(manager: manager))
     }
 
     var body: some View {
@@ -78,7 +78,7 @@ struct ConfigureSheet: View {
         HStack(spacing: 20) {
             Picker("Loops:", selection: $viewModel.numberOfLoops) {
                 Text("Infinite").tag(0)
-                ForEach(1...10, id: \.self) { count in
+                ForEach(1 ... 10, id: \.self) { count in
                     Text("\(count)").tag(count)
                 }
             }

--- a/Brooklyn/ConfigureSheet/ConfigureSheetViewModel.swift
+++ b/Brooklyn/ConfigureSheet/ConfigureSheetViewModel.swift
@@ -24,9 +24,9 @@ final class ConfigureSheetViewModel: ObservableObject {
 
     init(manager: BrooklynManager) {
         self.manager = manager
-        self.customize = manager.database.customize
-        self.numberOfLoops = manager.database.numberOfLoops
-        self.randomOrder = manager.database.randomOrder
+        customize = manager.database.customize
+        numberOfLoops = manager.database.numberOfLoops
+        randomOrder = manager.database.randomOrder
     }
 
     func isSelected(_ animation: Animation) -> Bool {

--- a/Brooklyn/Sources/Animation.swift
+++ b/Brooklyn/Sources/Animation.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// All 75 Brooklyn animations from the original Apple event.
-enum Animation: String, CaseIterable, Identifiable, Sendable {
+enum Animation: String, CaseIterable, Identifiable {
     case appleBits
     case auroraBorealis
     case avatarTissue
@@ -78,7 +78,9 @@ enum Animation: String, CaseIterable, Identifiable, Sendable {
     case zelda
     case zoetrope
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     /// Display name derived from the raw value (e.g., "ballPit" → "Ball Pit").
     var displayName: String {

--- a/Brooklyn/Sources/BrooklynManager.swift
+++ b/Brooklyn/Sources/BrooklynManager.swift
@@ -8,7 +8,7 @@ final class BrooklynManager {
 
     init(bundle: Bundle) {
         self.bundle = bundle
-        self.database = Database(moduleBundle: bundle)
+        database = Database(moduleBundle: bundle)
     }
 
     // MARK: - Animation Selection
@@ -63,8 +63,8 @@ final class BrooklynManager {
             items.append(AVPlayerItem(url: url))
         }
 
-        items += rest.flatMap { animation -> [AVPlayerItem] in
-            (0..<loops).compactMap { _ in
+        items += rest.flatMap { animation in
+            (0 ..< loops).compactMap { _ in
                 guard let url = animation.videoURL(in: bundle) else { return nil }
                 return AVPlayerItem(url: url)
             }

--- a/Brooklyn/Sources/BrooklynView.swift
+++ b/Brooklyn/Sources/BrooklynView.swift
@@ -13,11 +13,11 @@ final class BrooklynView: ScreenSaverView {
     private var playerLayer: AVPlayerLayer?
     private var configureSheetController: ConfigureSheetController?
     private var isAnimationStarted = false
-    nonisolated(unsafe) private var willStopObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var willStopObserver: NSObjectProtocol?
 
     // MARK: - Initialization
 
-    override init?(frame: NSRect, isPreview: Bool) {
+    override init?(frame: NSRect, isPreview _: Bool) {
         let actualIsPreview = frame.width < 400 && frame.height < 300
         super.init(frame: frame, isPreview: actualIsPreview)
 
@@ -39,7 +39,7 @@ final class BrooklynView: ScreenSaverView {
     }
 
     @available(*, unavailable)
-    required init?(coder: NSCoder) {
+    required init?(coder _: NSCoder) {
         fatalError("init(coder:) is not supported")
     }
 
@@ -56,8 +56,8 @@ final class BrooklynView: ScreenSaverView {
         layer.videoGravity = .resizeAspect
         self.layer?.addSublayer(layer)
 
-        self.player = loopPlayer
-        self.playerLayer = layer
+        player = loopPlayer
+        playerLayer = layer
     }
 
     // MARK: - Lifecycle
@@ -114,7 +114,9 @@ final class BrooklynView: ScreenSaverView {
         playerLayer?.frame = bounds
     }
 
-    override var hasConfigureSheet: Bool { true }
+    override var hasConfigureSheet: Bool {
+        true
+    }
 
     override var configureSheet: NSWindow? {
         guard let manager else { return nil }

--- a/Brooklyn/Sources/Database.swift
+++ b/Brooklyn/Sources/Database.swift
@@ -12,7 +12,7 @@ final class Database {
 
     init(moduleBundle: Bundle) {
         let identifier = moduleBundle.bundleIdentifier ?? "dev.nozomiishii.brooklyn"
-        self.defaults = ScreenSaverDefaults(forModuleWithName: identifier)
+        defaults = ScreenSaverDefaults(forModuleWithName: identifier)
         registerDefaults()
     }
 

--- a/Brooklyn/Sources/LoopPlayer.swift
+++ b/Brooklyn/Sources/LoopPlayer.swift
@@ -5,7 +5,7 @@ import AVFoundation
 /// When an item finishes playing, it is copied and re-appended to the queue,
 /// creating an infinite loop effect.
 final class LoopPlayer: AVQueuePlayer {
-    nonisolated(unsafe) private var itemDidFinishObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var itemDidFinishObserver: NSObjectProtocol?
 
     override init() {
         super.init()

--- a/BrooklynTests/AnimationTests.swift
+++ b/BrooklynTests/AnimationTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// match the actual files (appleBits, auroraBorealis, etc.), causing silent
 /// video load failures.
 final class AnimationTests: XCTestCase {
-
     // MARK: - File Name Matching
 
     func testAllAnimationsHaveMatchingMP4Files() {
@@ -16,7 +15,7 @@ final class AnimationTests: XCTestCase {
             XCTAssertNotNil(
                 url,
                 "Missing MP4 file for animation '\(animation.rawValue)'. "
-                + "Ensure \(animation.rawValue).mp4 exists in Resources/Animations/"
+                    + "Ensure \(animation.rawValue).mp4 exists in Resources/Animations/"
             )
         }
     }

--- a/BrooklynTests/BrooklynManagerTests.swift
+++ b/BrooklynTests/BrooklynManagerTests.swift
@@ -88,7 +88,8 @@ final class BrooklynManagerTests: XCTestCase {
 
         let items = manager.makePlayerItems()
         let hasOriginal = items.contains { item in
-            (item.asset as? AVURLAsset)?.url?.lastPathComponent == "original.mp4"
+            guard let url = (item.asset as? AVURLAsset)?.url else { return false }
+            return url.lastPathComponent == "original.mp4"
         }
 
         XCTAssertFalse(hasOriginal, "Original should not be in playlist when not selected")

--- a/BrooklynTests/BrooklynManagerTests.swift
+++ b/BrooklynTests/BrooklynManagerTests.swift
@@ -56,7 +56,8 @@ final class BrooklynManagerTests: XCTestCase {
 
         let items = manager.makePlayerItems()
         guard let firstItem = items.first,
-              let firstURL = (firstItem.asset as? AVURLAsset)?.url else {
+              let firstURL = (firstItem.asset as? AVURLAsset)?.url
+        else {
             XCTFail("First item must have a URL")
             return
         }
@@ -72,10 +73,10 @@ final class BrooklynManagerTests: XCTestCase {
         manager.database.randomOrder = false
 
         let items = manager.makePlayerItems()
-        let originalCount = items.filter { item in
+        let originalCount = items.count { item in
             guard let url = (item.asset as? AVURLAsset)?.url else { return false }
             return url.lastPathComponent == "original.mp4"
-        }.count
+        }
 
         XCTAssertEqual(originalCount, 1, "Original should appear exactly once (at the start)")
     }
@@ -87,8 +88,7 @@ final class BrooklynManagerTests: XCTestCase {
 
         let items = manager.makePlayerItems()
         let hasOriginal = items.contains { item in
-            guard let url = (item.asset as? AVURLAsset)?.url else { return false }
-            return url.lastPathComponent == "original.mp4"
+            (item.asset as? AVURLAsset)?.url?.lastPathComponent == "original.mp4"
         }
 
         XCTAssertFalse(hasOriginal, "Original should not be in playlist when not selected")
@@ -133,7 +133,7 @@ final class BrooklynManagerTests: XCTestCase {
     func testLoopsMultipliesItems() {
         manager.database.customize = true
         manager.database.selectedAnimations = [.appleBits]
-        manager.database.numberOfLoops = 2  // means 3 plays
+        manager.database.numberOfLoops = 2 // means 3 plays
 
         let items = manager.makePlayerItems()
         XCTAssertEqual(items.count, 3, "numberOfLoops=2 means each animation plays 3 times")

--- a/BrooklynTests/BrooklynViewTests.swift
+++ b/BrooklynTests/BrooklynViewTests.swift
@@ -7,7 +7,6 @@ import XCTest
 /// calls startAnimation multiple times, and fails to call stopAnimation.
 @MainActor
 final class BrooklynViewTests: XCTestCase {
-
     // MARK: - Ghost Instance Detection
 
     /// Regression: macOS 26 Tahoe creates instances with frame (0,0,0,0).
@@ -129,7 +128,7 @@ final class BrooklynViewTests: XCTestCase {
         }
 
         view.startAnimation() // Should not crash — player is nil
-        view.stopAnimation()  // Should not crash
+        view.stopAnimation() // Should not crash
     }
 
     // MARK: - General
@@ -146,10 +145,9 @@ final class BrooklynViewTests: XCTestCase {
 
     /// Regression: macOS 26 Tahoe ghost instances (frame .zero) must still provide
     /// a configure sheet so the Options button works in System Settings.
-    func testGhostInstanceProvidesConfigureSheet() {
-        let view = BrooklynView(frame: .zero, isPreview: true)
-        XCTAssertNotNil(view, "Ghost view should be created")
-        XCTAssertTrue(view!.hasConfigureSheet)
-        XCTAssertNotNil(view!.configureSheet, "Ghost instance must still provide a configure sheet")
+    func testGhostInstanceProvidesConfigureSheet() throws {
+        let view = try XCTUnwrap(BrooklynView(frame: .zero, isPreview: true), "Ghost view should be created")
+        XCTAssertTrue(view.hasConfigureSheet)
+        XCTAssertNotNil(view.configureSheet, "Ghost instance must still provide a configure sheet")
     }
 }

--- a/BrooklynTests/LoopPlayerTests.swift
+++ b/BrooklynTests/LoopPlayerTests.swift
@@ -6,7 +6,6 @@ import XCTest
 /// LoopPlayer must duplicate the item to keep the queue alive.
 @MainActor
 final class LoopPlayerTests: XCTestCase {
-
     func testSingleItemIsDuplicatedForLooping() {
         let bundle = Bundle(for: type(of: self))
         guard let url = Animation.appleBits.videoURL(in: bundle) else {
@@ -27,7 +26,8 @@ final class LoopPlayerTests: XCTestCase {
     func testMultipleItemsArePreserved() {
         let bundle = Bundle(for: type(of: self))
         guard let url1 = Animation.appleBits.videoURL(in: bundle),
-              let url2 = Animation.ballPit.videoURL(in: bundle) else {
+              let url2 = Animation.ballPit.videoURL(in: bundle)
+        else {
             XCTFail("MP4 files not found in test bundle")
             return
         }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,9 @@ Apple の 2018 年 Brooklyn イベントにインスパイアされた macOS ス
 make generate     # XcodeGen で project.yaml から Xcode プロジェクトを生成
 make build        # generate + Release ビルド
 make test         # generate + テスト実行
-make lint         # SwiftLint（swiftlint --config .swiftlint.yaml）
+make format       # SwiftFormat で自動整形
+make format-check # フォーマット差分チェック（CI 用）
+make lint         # SwiftLint（--strict）+ SwiftFormat チェック
 make install      # build + ~/Library/Screen Savers/ にコピー + codesign
 make uninstall    # スクリーンセーバーを削除
 make clean        # build/ と Brooklyn.xcodeproj を削除

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ make build        # generate + Release ビルド
 make test         # generate + テスト実行
 make format       # SwiftFormat で自動整形
 make format-check # フォーマット差分チェック（CI 用）
-make lint         # SwiftLint（--strict）+ SwiftFormat チェック
+make lint         # SwiftLint（--strict）
 make install      # build + ~/Library/Screen Savers/ にコピー + codesign
 make uninstall    # スクリーンセーバーを削除
 make clean        # build/ と Brooklyn.xcodeproj を削除

--- a/Canvas/AppDelegate.swift
+++ b/Canvas/AppDelegate.swift
@@ -6,7 +6,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var window: NSWindow?
     private var saverView: BrooklynView?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
+    func applicationDidFinishLaunching(_: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
 
@@ -30,18 +30,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let view = BrooklynView(frame: windowFrame, isPreview: false) {
             window.contentView = view
             view.startAnimation()
-            self.saverView = view
+            saverView = view
         }
 
         window.makeKeyAndOrderFront(nil)
         self.window = window
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    func applicationShouldTerminateAfterLastWindowClosed(_: NSApplication) -> Bool {
         true
     }
 
-    func applicationWillTerminate(_ notification: Notification) {
+    func applicationWillTerminate(_: Notification) {
         saverView?.stopAnimation()
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: generate build test lint clean install uninstall reset
+.PHONY: generate build test format format-check lint clean install uninstall reset
 
 # Generate Xcode project from project.yaml
 generate:
@@ -20,9 +20,18 @@ test: generate
 		-destination 'platform=macOS' \
 		-derivedDataPath build
 
+# Format Swift code (in-place)
+format:
+	mint run swiftformat .
+
+# Check formatting without modifying files (for CI)
+format-check:
+	mint run swiftformat --lint .
+
 # Lint Swift code
 lint:
-	swiftlint --config .swiftlint.yaml
+	mint run swiftlint --strict --config .swiftlint.yaml
+	mint run swiftformat --lint .
 
 # Install the screen saver
 install: build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: generate build test format format-check lint clean install uninstall reset
 
+SWIFT_SOURCES = Brooklyn BrooklynTests Canvas
+
 # Generate Xcode project from project.yaml
 generate:
 	xcodegen generate --spec project.yaml
@@ -22,16 +24,15 @@ test: generate
 
 # Format Swift code (in-place)
 format:
-	mint run swiftformat .
+	mint run swiftformat $(SWIFT_SOURCES)
 
 # Check formatting without modifying files (for CI)
 format-check:
-	mint run swiftformat --lint .
+	mint run swiftformat $(SWIFT_SOURCES) --lint
 
 # Lint Swift code
 lint:
-	mint run swiftlint --strict --config .swiftlint.yaml
-	mint run swiftformat --lint .
+	mint run swiftlint --strict --config .swiftlint.yaml --cache-path .swiftlint-cache $(SWIFT_SOURCES)
 
 # Install the screen saver
 install: build
@@ -54,4 +55,4 @@ reset:
 
 # Clean build artifacts
 clean:
-	rm -rf build Brooklyn.xcodeproj
+	rm -rf build Brooklyn.xcodeproj .swiftlint-cache

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,2 @@
+realm/SwiftLint@0.63.2
+nicklockwood/SwiftFormat@0.60.1


### PR DESCRIPTION
## Summary

SwiftLint + SwiftFormat を Mint 経由で導入し、コード品質の自動チェック基盤を構築。

## 変更内容

- `Mintfile` 追加 — SwiftLint@0.63.2 / SwiftFormat@0.60.1 のバージョン固定
- `.swiftlint.yaml` 追加 — デフォルトルール + `--strict`（warning=0 運用）、`line_length: 200`
- `.swiftformat` 追加 — デフォルト設定（Swift 6 対応）
- `Makefile` 更新 — `make format` / `make format-check` / `make lint`（`mint run` 経由）
- CI に `lint` ジョブ追加 — `build-and-test` と並列実行
- 既存コードを SwiftLint / SwiftFormat のデフォルトルールに準拠するよう修正
  - 冗長な `self` の削除
  - modifier の順序修正（`nonisolated(unsafe) private` → `private nonisolated(unsafe)`）
  - 未使用引数を `_` に変更
  - `filter().count` → `count(where:)`
  - テストの force unwrap → `XCTUnwrap`
  - range 演算子のスペース統一
  - scope 先頭の空行削除
  - 冗長な `Sendable` 準拠の削除（enum は暗黙的に Sendable）

## Test plan

- [x] `make format` → 差分なし
- [x] `make lint` → 違反ゼロ（SwiftLint --strict + SwiftFormat --lint）
- [x] `make build` → ビルド成功
- [x] `make test` → テスト全パス
- [ ] CI の `lint` ジョブが正常に完了すること