### PR TITLE
fix: narrow lsregister scope to Brooklyn.saver path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ reset:
 	-killall "System Settings" 2>/dev/null
 	rm -rf ~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Caches/*
 	rm -f ~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Preferences/ByHost/dev.nozomiishii.brooklyn.*.plist
-	-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -r -domain local -domain user
+	-/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f ~/Library/Screen\ Savers/Brooklyn.saver
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
## Summary
- `make reset` の `lsregister` を `-r -domain local -domain user`（全ドメインリスキャン）から `-f <path>`（Brooklyn.saver のみ強制再登録）に変更

## Background
従来の `-r -domain local -domain user` は LaunchServices DB 全体を再構築するため、数秒〜数十秒かかり他のアプリの登録にも影響する可能性があった。Brooklyn.saver だけを再登録すれば十分なので、`-f` でパス指定に絞った。

## Test plan
- [ ] `make reset` が正常に完了することを確認
- [ ] `make install` 後にスクリーンセーバーが認識されることを確認