### PR TITLE
chore: migrate reusable workflows to v3.0.0

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: GitHub Actions
 
 on:
   workflow_dispatch:
@@ -14,7 +14,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  github-actions:
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
 
 jobs:
-  secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  secret-scan:
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -18,10 +21,14 @@ jobs:
   lint:
     runs-on: macos-26
     timeout-minutes: 15
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Mint
         run: brew install mint
@@ -45,10 +52,14 @@ jobs:
   build-and-test:
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create draft releases and tags
+      pull-requests: write  # required by release-please to create/update release PRs
 
     outputs:
       release_created: ${{ steps.detect.outputs.release_created }}
@@ -50,16 +50,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run release-please github-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           npx --yes release-please@17.6.0 github-release \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect created release
         id: detect
@@ -82,7 +84,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: write  # required by gh release upload/edit to publish release assets
     steps:
       - name: Load secrets from 1Password
         id: secrets
@@ -103,6 +105,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -119,18 +122,20 @@ jobs:
           zip -r Brooklyn.saver.zip Brooklyn.saver
 
       - name: Upload to GitHub Release
-        run: |
-          gh release upload "${{ needs.create-draft-release.outputs.tag_name }}" \
-            build/Build/Products/Release/Brooklyn.saver.zip
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: |
+          gh release upload "${TAG_NAME}" \
+            build/Build/Products/Release/Brooklyn.saver.zip
 
       - name: Publish Release
-        run: |
-          gh release edit "${{ needs.create-draft-release.outputs.tag_name }}" \
-            --draft=false
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: |
+          gh release edit "${TAG_NAME}" \
+            --draft=false
 
   # publish 後に次の release PR を作成/更新
   release-pr:
@@ -139,8 +144,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create the release PR branch
+      pull-requests: write  # required by release-please to create/update release PRs
 
     steps:
       - name: Load secrets from 1Password
@@ -162,16 +167,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run release-please release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           npx --yes release-please@17.6.0 release-pr \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   homebrew-update:
     needs: [create-draft-release, upload-assets]


### PR DESCRIPTION
## 概要

`nozomiishii/workflows` v3.0.0 リリースに先行して caller 側を移行する。pin は main HEAD の SHA（v3.0.0 release PR merge 直前の状態）を使用。

## 変更内容

- `_actionlint.yaml` → **`_github-actions.yaml`**
  - 呼び先を v2 aggregator `github-actions.yaml`（actionlint + zizmor）に差し替え
  - permissions に `actions: read` 追加（zizmor auditor persona 用）
  - job / workflow 名も v2 に合わせて rename
- `_secretlint.yaml` → **`_secret-scan.yaml`**
  - 呼び先を v2 concept-named `secret-scan.yaml` に差し替え
- `_pull-request.yaml`
  - SHA pin を v3.0.0（未リリース、main HEAD）に bump

## ⚠️ branch protection 更新が必要

この PR を merge する前に、default branch の required status checks を以下に更新:

| 旧 | 新 |
|---|---|
| `actionlint / lint` | `github-actions / required` |
| `secretlint / scan` | `secret-scan / secretlint` |
| `pull-request / validate` | そのまま |

## 関連

- 既存の renovate PR（SHA の単純 bump）は本 PR で代替するので close する
- `nozomiishii/workflows` 側の v3.0.0 release PR は全 caller migration 完了後に merge される予定
