### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -18,10 +21,14 @@ jobs:
   lint:
     runs-on: macos-26
     timeout-minutes: 15
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Mint
         run: brew install mint
@@ -45,10 +52,14 @@ jobs:
   build-and-test:
     runs-on: macos-26
     timeout-minutes: 30
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install XcodeGen
         run: brew install xcodegen

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create draft releases and tags
+      pull-requests: write  # required by release-please to create/update release PRs
 
     outputs:
       release_created: ${{ steps.detect.outputs.release_created }}
@@ -50,16 +50,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run release-please github-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           npx --yes release-please@17.6.0 github-release \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect created release
         id: detect
@@ -82,7 +84,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: write  # required by gh release upload/edit to publish release assets
     steps:
       - name: Load secrets from 1Password
         id: secrets
@@ -103,6 +105,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Install XcodeGen
         run: brew install xcodegen
@@ -139,8 +142,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create the release PR branch
+      pull-requests: write  # required by release-please to create/update release PRs
 
     steps:
       - name: Load secrets from 1Password
@@ -162,16 +165,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run release-please release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           npx --yes release-please@17.6.0 release-pr \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
   homebrew-update:
     needs: [create-draft-release, upload-assets]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,18 +122,20 @@ jobs:
           zip -r Brooklyn.saver.zip Brooklyn.saver
 
       - name: Upload to GitHub Release
-        run: |
-          gh release upload "${{ needs.create-draft-release.outputs.tag_name }}" \
-            build/Build/Products/Release/Brooklyn.saver.zip
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: |
+          gh release upload "${TAG_NAME}" \
+            build/Build/Products/Release/Brooklyn.saver.zip
 
       - name: Publish Release
-        run: |
-          gh release edit "${{ needs.create-draft-release.outputs.tag_name }}" \
-            --draft=false
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: |
+          gh release edit "${TAG_NAME}" \
+            --draft=false
 
   # publish 後に次の release PR を作成/更新
   release-pr:


### PR DESCRIPTION
## Summary

Migration PR (#59) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes
- `_github-actions.yaml` / `_pull-request.yaml`: permissions に justification コメント
- `ci.yaml`: top-level `permissions: {}` + job 最小 permissions + `persist-credentials: false`
- `release.yaml`:
  - `persist-credentials: false` + permissions コメント
  - `release-please` 呼び出しの `${{ }}` を `env:` 経由に refactor（template-injection）
  - `gh release upload` / `gh release edit` の `tag_name` も `env:` 経由に refactor（残っていた template-injection を解消）

## Test plan
- [x] `github-actions / required` 緑
- [x] `github-actions / zizmor` 緑
- [x] `secret-scan / secretlint` 緑
- [x] `pull-request / validate` 緑
