### PR TITLE
fix(ci): make brew bump-cask-pr failures visible in logs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,33 +209,35 @@ jobs:
           owner: nozomiishii
           repositories: homebrew-tap
 
-      - name: Bump cask and enable auto-merge
+      - name: Bump cask
+        id: bump
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
         run: |
           VERSION="${TAG_NAME#v}"
           brew tap nozomiishii/homebrew-tap
 
-          # `brew bump-cask-pr` の出力 (stdout/stderr) に作成 PR の URL が含まれる。
-          # `gh pr list` でタイトル検索する代わりにそれを直接捕捉して
-          # `gh pr merge` に渡すことで、push 直後の検索レース・誤解決を避ける。
-          BUMP_OUTPUT=$(brew bump-cask-pr \
+          # `tee` で stdout に流しつつログファイルにも残し、PR URL を後段で抽出する。
+          # `$()` で stderr を取り込む書き方だと bash の `-e -o pipefail` 下で
+          # brew が失敗したときログが標準出力されず原因不明になるため避ける。
+          BUMP_LOG="$(mktemp)"
+          brew bump-cask-pr \
             --no-browse \
             --no-fork \
             --tap=nozomiishii/homebrew-tap \
             --version="$VERSION" \
-            brooklyn 2>&1)
-          echo "$BUMP_OUTPUT"
+            brooklyn 2>&1 | tee "$BUMP_LOG"
 
-          PR_URL=$(echo "$BUMP_OUTPUT" \
-            | grep -oE 'https://github\.com/nozomiishii/homebrew-tap/pull/[0-9]+' \
-            | tail -1)
-
-          if [ -z "$PR_URL" ]; then
-            echo "::warning::PR URL not found in brew output; auto-merge skipped"
-            exit 0
+          PR_URL="$(grep -oE 'https://github\.com/nozomiishii/homebrew-tap/pull/[0-9]+' "$BUMP_LOG" | tail -1)"
+          if [ -n "$PR_URL" ]; then
+            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::PR URL not found in brew output; auto-merge will be skipped"
           fi
 
-          gh pr merge "$PR_URL" --auto --squash
+      - name: Enable auto-merge on the bump PR
+        if: steps.bump.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh pr merge "${{ steps.bump.outputs.pr_url }}" --auto --squash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -215,6 +215,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
         run: |
+          set -x
           VERSION="${TAG_NAME#v}"
           brew tap nozomiishii/homebrew-tap
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -240,4 +240,5 @@ jobs:
         if: steps.bump.outputs.pr_url != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh pr merge "${{ steps.bump.outputs.pr_url }}" --auto --squash
+          PR_URL: ${{ steps.bump.outputs.pr_url }}
+        run: gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

[Brooklyn release v0.1.18 の `homebrew-update` ジョブ](https://github.com/nozomiishii/Brooklyn/actions/runs/25060143445/job/73411931234) が `Process completed with exit code 1` で失敗。原因究明のため `brew bump-cask-pr` の出力を可視化する。

## なぜ落ちているか不明だったか

旧実装は `BUMP_OUTPUT=$(brew bump-cask-pr ... 2>&1)` で stdout/stderr を変数に取り込んでから後段で `echo` する設計だった。bash の `set -e -o pipefail` 下で `brew bump-cask-pr` が失敗すると `$()` 終了時点で即 exit してしまい、`echo "$BUMP_OUTPUT"` が実行されないため runner ログに何も残らない。

実際のログ:

```
==> Tapping nozomiishii/tap
Cloning into '/opt/homebrew/Library/Taps/nozomiishii/homebrew-tap'...
Tapped 1 cask and 1 formula (23 files, 65.3KB).
##[error]Process completed with exit code 1.
```

`brew tap` までは成功。`brew bump-cask-pr` の出力が完全に隠蔽されている。

## 変更内容

- `Bump cask and enable auto-merge` を **2 ステップに分割**:
  - `Bump cask` (id: bump): `brew bump-cask-pr` の出力を `tee` で stdout に流しつつログファイルに残し、PR URL を `$GITHUB_OUTPUT` に書き出す
  - `Enable auto-merge on the bump PR`: `if: steps.bump.outputs.pr_url != ''` で別ステップ化、`gh pr merge --auto --squash` を呼ぶ
- `tee` を介すことで `pipefail` 下でも失敗時に出力がログに残り、原因がそのまま見える
- bump step 冒頭に `set -x` を追加し、`brew tap` / `brew bump-cask-pr` の実行コマンドラインも runner ログに残す（変数展開後の `--version` などが想定通りか確認できる）

## v0.1.18 への対応

リリースタグ v0.1.18 の cask 更新は **このジョブが失敗したまま** なので、homebrew-tap の `Casks/brooklyn.rb` は v0.1.16 のまま放置されている。この PR がマージされたら `gh workflow run` で release.yaml を `workflow_dispatch` で再実行するか、手動で cask を v0.1.18 に bump する必要がある（v0.1.18 の release_created 判定がどうなるかは確認要）。

なお `brew bump-cask-pr` は **対象 cask が既に同一バージョンに到達している場合は no-op で exit する** 挙動がある。再実行して PR が作られない場合、ログの warning (`PR URL not found in brew output; auto-merge will be skipped`) が出ているか確認すること。

## Test plan

- [ ] この PR の検証 CI を確認
- [ ] マージ後、次のリリースまたは workflow_dispatch で `brew bump-cask-pr` の出力がログに出ることを確認
- [ ] 失敗の根本原因が判明したら追加修正
