### PR TITLE
fix(ci): drop unsupported --tap flag from brew bump-cask-pr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -226,9 +226,8 @@ jobs:
           brew bump-cask-pr \
             --no-browse \
             --no-fork \
-            --tap=nozomiishii/homebrew-tap \
             --version="$VERSION" \
-            brooklyn 2>&1 | tee "$BUMP_LOG"
+            nozomiishii/tap/brooklyn 2>&1 | tee "$BUMP_LOG"
 
           PR_URL="$(grep -oE 'https://github\.com/nozomiishii/homebrew-tap/pull/[0-9]+' "$BUMP_LOG" | tail -1)"
           if [ -n "$PR_URL" ]; then


### PR DESCRIPTION
## Summary

[#67](https://github.com/nozomiishii/Brooklyn/pull/67) の観測装置によって [v0.1.19 release run](https://github.com/nozomiishii/Brooklyn/actions/runs/25061955815/job/73418850415) で真因が判明したので修正する。

## 原因

`brew bump-cask-pr` には **`--tap` オプションが存在しない**。実行ログ:

```
+ brew bump-cask-pr --no-browse --no-fork --tap=nozomiishii/homebrew-tap --version=0.1.19 brooklyn
Warning: bump-cask-pr is a developer command, so Homebrew's developer mode has been automatically turned on.
Usage: brew bump-cask-pr [options] cask
...
##[error]invalid option: --tap=nozomiishii/homebrew-tap
##[error]Process completed with exit code 1.
```

usage で受け付けるオプション一覧:

```
--dry-run / --write-only / --commit / --no-audit / --no-style /
--no-browse / --no-fork / --version / --version-arm / --version-intel /
--message / --url / --sha256 / --fork-org / --debug / --quiet / --verbose / --help
```

`--tap` は無く、cask 名で tap を解決する仕様（事前に `brew tap` 済みの tap が前提）。

## 変更内容

```diff
   brew bump-cask-pr \
     --no-browse \
     --no-fork \
-    --tap=nozomiishii/homebrew-tap \
     --version="$VERSION" \
-    brooklyn 2>&1 | tee "$BUMP_LOG"
+    nozomiishii/tap/brooklyn 2>&1 | tee "$BUMP_LOG"
```

- `--tap` を削除（CLI に存在しないオプション）
- cask 名を `brooklyn` → `nozomiishii/tap/brooklyn` に変更（フルパス指定で曖昧さを排除）

`brew tap nozomiishii/homebrew-tap` は前段で実行済み（log で `Tapping nozomiishii/tap` を確認）なので、`nozomiishii/tap/brooklyn` でフル qualified に解決される。

## v0.1.18 / v0.1.19 の cask 反映

両リリースとも `homebrew-update` が失敗して `Casks/brooklyn.rb` は v0.1.16 のまま。マージ後に **次のリリース (v0.1.20) を発生させる** か、homebrew-tap 側で手動で v0.1.19 への bump PR を出して追いつかせる必要あり。

## Test plan

- [ ] この PR の検証 CI 通過
- [ ] マージ後の次のリリースで `brew bump-cask-pr` が exit 0 で完了し、homebrew-tap に PR が作成される
- [ ] auto-merge が有効化され、required checks pass 後に自動マージされる
