### PR TITLE
fix(ci): use brew bump-cask-pr --write-only and open PR ourselves

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -209,8 +209,7 @@ jobs:
           owner: nozomiishii
           repositories: homebrew-tap
 
-      - name: Bump cask
-        id: bump
+      - name: Bump cask file (write only)
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
@@ -218,50 +217,47 @@ jobs:
           set -x
           VERSION="${TAG_NAME#v}"
           brew tap nozomiishii/homebrew-tap
-
-          # `tee` で stdout に流しつつログファイルにも残し、PR URL を後段で抽出する。
-          # `$()` で stderr を取り込む書き方だと bash の `-e -o pipefail` 下で
-          # brew が失敗したときログが標準出力されず原因不明になるため避ける。
-          BUMP_LOG="$(mktemp)"
+          # `--write-only` だとファイル書き換え + brew style --fix + brew audit のみ
+          # 走り、commit/push/PR 作成は行われない。後段で自前に PR を作ることで
+          # PR title を最初から Conventional Commits 形式にし、CI の二重起動を避ける。
           brew bump-cask-pr \
-            --no-browse \
-            --no-fork \
+            --write-only \
             --version="$VERSION" \
-            nozomiishii/tap/brooklyn 2>&1 | tee "$BUMP_LOG"
+            nozomiishii/tap/brooklyn
 
-          PR_URL="$(grep -oE 'https://github\.com/nozomiishii/homebrew-tap/pull/[0-9]+' "$BUMP_LOG" | tail -1)"
-          if [ -n "$PR_URL" ]; then
-            echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::PR URL not found in brew output; auto-merge will be skipped"
-          fi
-
-      - name: Decorate the bump PR
-        if: steps.bump.outputs.pr_url != ''
+      - name: Commit, push and open PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_URL: ${{ steps.bump.outputs.pr_url }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          # `brew bump-cask-pr` のデフォルト PR title (`brooklyn 0.1.20`) は
-          # homebrew-tap の `pull-request / validate` (Conventional Commits) を
-          # 通らないので、ここで書き換える。
-          gh pr edit "$PR_URL" --title "chore: update brooklyn to ${TAG_NAME}"
+          set -x
+          TAP_DIR="$(brew --repository nozomiishii/homebrew-tap)"
+          cd "$TAP_DIR"
 
-          # Brooklyn release tag を本文末尾に追記。release-please の release
-          # PR から起動している場合 (head commit が `chore: release X.Y.Z (#N)`)、
-          # `(#N)` を抽出して release PR リンクも併記する。
+          BRANCH="bump-brooklyn-${TAG_NAME}"
+          MSG="chore: update brooklyn to ${TAG_NAME}"
+          git config user.name "nozomiishii-release[bot]"
+          git config user.email "nozomiishii-release[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Casks/brooklyn.rb
+          git commit -m "$MSG"
+          AUTH=$(echo -n "x-access-token:${HOMEBREW_GITHUB_API_TOKEN}" | base64)
+          git -c "http.extraheader=Authorization: Basic ${AUTH}" push -u origin "$BRANCH"
+
+          # release-please の release PR (head commit が `chore: release X.Y.Z (#N)`)
+          # から起動した場合は `(#N)` を抽出して release PR リンクも併記する。
           BODY="Bumped from [Brooklyn ${TAG_NAME}](https://github.com/nozomiishii/Brooklyn/releases/tag/${TAG_NAME})."
           RELEASE_PR_NUMBER="$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1 | grep -oE '#[0-9]+' | head -1 | tr -d '#')"
           if [ -n "$RELEASE_PR_NUMBER" ]; then
             BODY="${BODY}"$'\n\n'"Release PR: https://github.com/nozomiishii/Brooklyn/pull/${RELEASE_PR_NUMBER}"
           fi
-          gh pr comment "$PR_URL" --body "$BODY"
 
-      - name: Enable auto-merge on the bump PR
-        if: steps.bump.outputs.pr_url != ''
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_URL: ${{ steps.bump.outputs.pr_url }}
-        run: gh pr merge "$PR_URL" --auto --squash
+          PR_URL=$(gh pr create \
+            --repo nozomiishii/homebrew-tap \
+            --base main \
+            --head "$BRANCH" \
+            --title "$MSG" \
+            --body "$BODY")
+          gh pr merge "$PR_URL" --auto --squash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -236,6 +236,29 @@ jobs:
             echo "::warning::PR URL not found in brew output; auto-merge will be skipped"
           fi
 
+      - name: Decorate the bump PR
+        if: steps.bump.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ steps.bump.outputs.pr_url }}
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          # `brew bump-cask-pr` のデフォルト PR title (`brooklyn 0.1.20`) は
+          # homebrew-tap の `pull-request / validate` (Conventional Commits) を
+          # 通らないので、ここで書き換える。
+          gh pr edit "$PR_URL" --title "chore: update brooklyn to ${TAG_NAME}"
+
+          # Brooklyn release tag を本文末尾に追記。release-please の release
+          # PR から起動している場合 (head commit が `chore: release X.Y.Z (#N)`)、
+          # `(#N)` を抽出して release PR リンクも併記する。
+          BODY="Bumped from [Brooklyn ${TAG_NAME}](https://github.com/nozomiishii/Brooklyn/releases/tag/${TAG_NAME})."
+          RELEASE_PR_NUMBER="$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1 | grep -oE '#[0-9]+' | head -1 | tr -d '#')"
+          if [ -n "$RELEASE_PR_NUMBER" ]; then
+            BODY="${BODY}"$'\n\n'"Release PR: https://github.com/nozomiishii/Brooklyn/pull/${RELEASE_PR_NUMBER}"
+          fi
+          gh pr comment "$PR_URL" --body "$BODY"
+
       - name: Enable auto-merge on the bump PR
         if: steps.bump.outputs.pr_url != ''
         env:


### PR DESCRIPTION
## Summary

`brew bump-cask-pr` のデフォルト PR title (`brooklyn 0.1.20`) は homebrew-tap 側の `pull-request / validate` (Conventional Commits) を通らない。CLI のソース ([`bump-cask-pr.rb`](https://github.com/Homebrew/brew/blob/main/Library/Homebrew/dev-cmd/bump-cask-pr.rb)) で `commit_message ||= "#{cask.token} #{commit_version}"` がハードコードされており title を変更するフラグも環境変数も提供されていないため、

- `--write-only` でファイル書き換え + sha256 再計算 + `brew style --fix` + `brew audit` のみ走らせ
- commit / push / PR 作成は自前で行う

形に切り替える。これで **PR は最初から Conventional Commits 形式の title で立つ**ため、`gh pr edit` で書き換える必要がなく、`pull-request / validate` の二重起動も発生しない。

## 観測した症状

[homebrew-tap#22](https://github.com/nozomiishii/homebrew-tap/pull/22):
- title: `brooklyn 0.1.20`
- `pull-request / validate` が FAILURE

`gh pr edit --title` で書き換える初期案 (3dd1a18) では fail run + pass run の 2 回が走る挙動になり、無駄が出る。

## 変更内容

`Bump cask` ステップ + `Decorate the bump PR` ステップ + `Enable auto-merge` ステップを、以下の 2 ステップに集約:

### `Bump cask file (write only)`

```sh
brew bump-cask-pr \
  --write-only \
  --version="$VERSION" \
  nozomiishii/tap/brooklyn
```

`--write-only` だと `cask.sourcefile_path` が編集された状態で CLI がそこで return する (`return if args.write_only? && !args.commit?`)。sha256 計算 / brew style --fix / brew audit はその前に走る。

### `Commit, push and open PR`

`brew --repository nozomiishii/homebrew-tap` で tap の clone path に移動し、`bump-brooklyn-${TAG_NAME}` ブランチを切って commit → push → `gh pr create --title "chore: update brooklyn to ${TAG_NAME}"` → `gh pr merge --auto --squash`。

PR 本文には Brooklyn release tag リンクを常に入れ、release-please の release PR (`chore: release X.Y.Z (#N)`) から起動している場合は `(#N)` を抽出して release PR リンクも併記する。

## なぜ `--write-only` が成立するか

`Library/Homebrew/dev-cmd/bump-cask-pr.rb` の動作順:

```ruby
Utils::Inreplace.inreplace_pairs(sourcefile_path, replacement_pairs, ...)
run_cask_audit(cask, old_contents, audit_exceptions)
run_cask_style(cask, old_contents)
return if args.write_only? && !args.commit?   # ← --write-only 単独でここで終了
```

つまり `--write-only` 単独でも:
- ✅ ファイル書き換え (sha256 自動計算込み)
- ✅ `brew style --fix`
- ✅ `brew audit`

が走る。失われるのは fork / push / PR 作成だけ。

## Test plan

- [ ] CI green
- [ ] 次の Brooklyn release で `brew bump-cask-pr --write-only` が完走
- [ ] 自前で立てた PR が最初から `chore: update brooklyn to vX.Y.Z` の title を持つ
- [ ] homebrew-tap の `pull-request / validate` を 1 回で pass
- [ ] auto-merge が enable され、required checks pass 後に自動 squash merge
