### PR TITLE
fix(ci): rollback orphan branch when PR creation fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -246,6 +246,20 @@ jobs:
           AUTH=$(echo -n "x-access-token:${HOMEBREW_GITHUB_API_TOKEN}" | base64)
           git -c "http.extraheader=Authorization: Basic ${AUTH}" push -u origin "$BRANCH"
 
+          # `gh pr create` が失敗すると push したブランチだけが remote に残り、
+          # 孤立ブランチが溜まる。EXIT trap で roll-back し、PR 作成成功後は
+          # PR_CREATED=1 で抑止する。`gh pr merge --auto` の失敗時はブランチを
+          # 残す（PR は作成済みなので手動 merge で進められる）。
+          PR_CREATED=0
+          cleanup_orphan_branch() {
+            if [ "$PR_CREATED" = "0" ]; then
+              echo "::warning::PR not created — deleting orphan branch ${BRANCH}"
+              git -c "http.extraheader=Authorization: Basic ${AUTH}" \
+                push origin --delete "$BRANCH" || true
+            fi
+          }
+          trap cleanup_orphan_branch EXIT
+
           # release-please の release PR (head commit が `chore: release X.Y.Z (#N)`)
           # から起動した場合は `(#N)` を抽出して release PR リンクも併記する。
           BODY="Bumped from [Brooklyn ${TAG_NAME}](https://github.com/nozomiishii/Brooklyn/releases/tag/${TAG_NAME})."
@@ -260,4 +274,6 @@ jobs:
             --head "$BRANCH" \
             --title "$MSG" \
             --body "$BODY")
+          PR_CREATED=1
+
           gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

`Commit, push and open PR` ステップで `git push` は通ったが `gh pr create` で失敗した場合、homebrew-tap に `bump-brooklyn-vX.Y.Z` ブランチだけが孤立して残ってしまう。EXIT trap で roll-back を仕込み、`gh pr create` 通過後は `PR_CREATED=1` で抑止する。

## 背景

`brew bump-cask-pr --write-only` ベースの新フロー (#71) は、push と PR 作成が別操作なので原子性がない。実害は cask 反映の遅延だけだが、過去 `mislav/bump-homebrew-formula-action` で `update-git-harvest.rb-1777372050` のような孤立ブランチが残ったときに掃除に手間がかかった経験から、防御的に対処したい。

## 変更内容

```sh
PR_CREATED=0
cleanup_orphan_branch() {
  if [ "$PR_CREATED" = "0" ]; then
    echo "::warning::PR not created — deleting orphan branch ${BRANCH}"
    git -c "http.extraheader=Authorization: Basic ${AUTH}" \
      push origin --delete "$BRANCH" || true
  fi
}
trap cleanup_orphan_branch EXIT

PR_URL=$(gh pr create ...)
PR_CREATED=1   # ここまで通ったら trap は no-op

gh pr merge "$PR_URL" --auto --squash
```

- `gh pr create` 失敗 → trap が走り、push したブランチを delete → remote が完全に元の状態に戻る
- `gh pr create` 成功後の `gh pr merge --auto` 失敗 → ブランチは残す（PR 作成済みなので手動マージで進められる）
- 正常系では `PR_CREATED=1` のため trap は no-op

## Test plan

- [ ] CI green
- [ ] 次の Brooklyn release で正常系 (PR 作成成功) ではブランチが残ったまま auto-merge が動作する
- [ ] 異常系 (PR 作成失敗) は実環境で再現しにくいが、`||` 連結で `set -e` を妨げない・`PR_CREATED` 判定で no-op 化していることを review で確認する
