### PR TITLE
chore(ci): relabel bump PR body 'Bumped from' to 'Release Note:'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -262,7 +262,7 @@ jobs:
 
           # release-please の release PR (head commit が `chore: release X.Y.Z (#N)`)
           # から起動した場合は `(#N)` を抽出して release PR リンクも併記する。
-          BODY="Bumped from [Brooklyn ${TAG_NAME}](https://github.com/nozomiishii/Brooklyn/releases/tag/${TAG_NAME})."
+          BODY="Release Note: [Brooklyn ${TAG_NAME}](https://github.com/nozomiishii/Brooklyn/releases/tag/${TAG_NAME})"
           RELEASE_PR_NUMBER="$(printf '%s\n' "$HEAD_COMMIT_MESSAGE" | head -1 | grep -oE '#[0-9]+' | head -1 | tr -d '#')"
           if [ -n "$RELEASE_PR_NUMBER" ]; then
             BODY="${BODY}"$'\n\n'"Release PR: https://github.com/nozomiishii/Brooklyn/pull/${RELEASE_PR_NUMBER}"


### PR DESCRIPTION
## Summary

`brew bump-cask-pr --write-only` で作る cask 更新 PR の本文ラベルを変更:

- `Bumped from [Brooklyn vX.Y.Z](...)`  →  `Release Note: [Brooklyn vX.Y.Z](...)`

## 動機

リンク先が GitHub release notes ページなので、「Bumped from」より「Release Note:」の方がリンクの意味が直感的。`Release PR:` ラベルとも整合する。あわせて末尾のピリオドを削除して `Release PR:` と表記揃え。

## 例

Before:
```
Bumped from [Brooklyn v0.1.21](...).

Release PR: https://github.com/nozomiishii/Brooklyn/pull/72
```

After:
```
Release Note: [Brooklyn v0.1.21](...)

Release PR: https://github.com/nozomiishii/Brooklyn/pull/72
```

## Test plan

- [ ] CI green
- [ ] 次の Brooklyn release で生成される cask 更新 PR の本文が新ラベルになる
