### PR TITLE
chore: use swiftlint default line_length

### DIFF
--- a/.swiftlint.yaml
+++ b/.swiftlint.yaml
@@ -1,4 +1,2 @@
 disabled_rules:
   - trailing_comma # SwiftFormat が trailing comma を管理
-
-line_length: 200

--- a/Brooklyn/ConfigureSheet/ConfigureSheet.swift
+++ b/Brooklyn/ConfigureSheet/ConfigureSheet.swift
@@ -93,8 +93,10 @@ struct ConfigureSheet: View {
     // MARK: - Footer
 
     private var footer: some View {
-        HStack {
-            Text("v\(Bundle(for: BrooklynView.self).object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?")")
+        let bundle = Bundle(for: BrooklynView.self)
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        return HStack {
+            Text("v\(version)")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
             Spacer()


### PR DESCRIPTION
## 概要

`.swiftlint.yaml` の `line_length: 200` 上書きを削除し、SwiftLint デフォルト（warning: 120 / error: 200）に戻す。

`make lint` は `--strict` で実行されるため、warning も CI で fail 扱いになる。実質 200 文字までの行が許容されてしまっていた。

## 変更内容

- `.swiftlint.yaml`: `line_length: 200` を削除
- `Brooklyn/ConfigureSheet/ConfigureSheet.swift`: 削除に伴い 131 文字になっていた `footer` のバージョン取得行を `bundle` / `version` の 2 つのローカル定数に分解

## 確認

- `make lint`: 0 violations
- `make format-check`: 差分なし
