### PR TITLE
chore: trim redundant command sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Apple の 2018 年 Brooklyn イベントにインスパイアされた macOS スクリーンセーバー。[Pedro Carrasco のオリジナル](https://github.com/pedrommcarrasco/Brooklyn)を Swift 6 / macOS 26 (Tahoe) / Apple Silicon 向けにモダンに再実装したもの。75 個の MP4 アニメーションを `AVPlayerLayer` でループ再生する。
 
-## コマンド
+## Canvas での動作確認
 
-```bash
-make generate     # XcodeGen で project.yaml から Xcode プロジェクトを生成
-make build        # generate + Release ビルド
-make test         # generate + テスト実行
-make format       # SwiftFormat で自動整形
-make format-check # フォーマット差分チェック（CI 用）
-make lint         # SwiftLint（--strict）
-make install      # build + ~/Library/Screen Savers/ にコピー + codesign
-make uninstall    # スクリーンセーバーを削除
-make clean        # build/ と Brooklyn.xcodeproj を削除
-```
+`.saver` をインストールせずにデバッグするには Canvas ターゲットを使う:
 
-Canvas（デバッグ用アプリ）で `.saver` をインストールせずに動作確認:
 ```bash
 make generate && open Brooklyn.xcodeproj  # Xcode で Canvas スキームを実行
 ```


### PR DESCRIPTION
## Summary

`CLAUDE.md` の `## コマンド` から、`make` ターゲットを単純列挙していたコードブロックを削除する（`Makefile` を読めば自明なため）。

## 動機

`Makefile` に書かれている内容を `CLAUDE.md` に重複して保持すると、片方の更新時にもう一方が drift する。正本を `Makefile` に一本化する。

## 残置するもの

- Canvas でのデバッグ手順（`make generate && open Brooklyn.xcodeproj` で Xcode の Canvas スキームを起動する流れ）は `## Canvas での動作確認` セクションとして残置。`Makefile` 単体からは判らない GUI 操作とのコンボのため。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] Canvas での動作確認手順が残っている
