### PR TITLE
chore: trim derivable sections from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,12 +53,6 @@ BrooklynView (ScreenSaverView)
 
 `Animation` enum の `rawValue` が `Resources/Animations/` 内のファイル名（拡張子なし）と一致する必要がある。不一致があると黒画面になる。`AnimationTests.testAllAnimationsHaveMatchingMP4Files` で検証済み。
 
-## CI / リリース
-
-- **CI（ci.yaml）**: push / 全 PR で `make build` + arm64 検証 + 75 MP4 検証 + `make test`
-- **Release（release.yaml）**: `main` push / `workflow_dispatch` で 4 ジョブ実行（`create-draft-release` → `upload-assets` → `homebrew-update` → `release-pr`）
-- **actionlint / secretlint / pull-request title**: git-harvest と共通の品質チェック
-
 ## Git・GitHub・Conventional Commits
 
 - PR タイトルは英語、semantic commit 形式、小文字開始（`_pull-request.yaml` で検証）


### PR DESCRIPTION
## Summary

`CLAUDE.md` の追加トリム第 2 弾。先行 PR でコマンドリストを削った後、見直して **「ファイル一覧 / ディレクトリ列挙 / format-lint コマンドの再記述」** など、`ls` / `package.json` / `Makefile` / `.github/workflows/` を読めば自明な記述をさらに削除する。

## 変更内容（repo によって異なる）

- 「アーキテクチャ概要」配下の主要ディレクトリ列挙
- 「重要なパターン」内の "format / lint コマンドを使え" 系の箇条書き
- workflow ファイル列挙（`.github/workflows/` を読めば自明）
- ファイル名と短い説明だけのリスト

## 動機

`package.json` scripts / `Makefile` / ファイル一覧を `CLAUDE.md` に重複して保持すると drift する。WHY や非自明な制約は残し、それ以外は正本（コード・スクリプト・設定）に一本化する。

## Test plan

- [ ] `CLAUDE.md` のレンダリングが崩れていない
- [ ] WHY (理由) を含む記述は残っている
