### PR TITLE
chore: drop systematized rules from claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,10 +49,6 @@ BrooklynView (ScreenSaverView)
 - NotificationCenter オブザーバーは `nonisolated(unsafe)` で保持
 - 通知コールバックから `@MainActor` メソッドを呼ぶ際は `MainActor.assumeIsolated` を使用
 
-### Animation enum と MP4 ファイルの対応
-
-`Animation` enum の `rawValue` が `Resources/Animations/` 内のファイル名（拡張子なし）と一致する必要がある。不一致があると黒画面になる。`AnimationTests.testAllAnimationsHaveMatchingMP4Files` で検証済み。
-
 ## Git・GitHub・Conventional Commits
 
 - PR タイトルは英語、semantic commit 形式、小文字開始（`_pull-request.yaml` で検証）


### PR DESCRIPTION
## Summary

`CLAUDE.md` の `### Animation enum と MP4 ファイルの対応` サブセクションを削除する。同じ制約は **`AnimationTests.testAllAnimationsHaveMatchingMP4Files`** が CI で検証しており、不一致が発生すればテストが落ちて即座に検出される。

## 動機

ルールを文章で書いて test/CI で同じことを強制すると、片方の更新時に drift する。仕組みで強制している事実は仕組み側に一本化し、`CLAUDE.md` を軽く保つ。

## Test plan

- [ ] `AnimationTests.testAllAnimationsHaveMatchingMP4Files` が CI で引き続き走っている
- [ ] `CLAUDE.md` のレンダリングが崩れていない
