### PR TITLE
fix: scope release app token permissions and pin op cli version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -45,6 +48,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -89,6 +94,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -100,6 +108,7 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -151,6 +160,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -162,6 +174,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -195,6 +209,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -208,6 +225,8 @@ jobs:
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
           owner: nozomiishii
           repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Bump cask file (write only)
         env:


### PR DESCRIPTION
## 概要

zizmor v1.25.x で新たに CI を落とす 2 つの finding を先回りで正攻法に解消する。

- **github-app (high)**: `actions/create-github-app-token` を blanket 権限で発行していたため、各 job が必要とする最小権限のみを明示する。
- **unpinned-tools (medium)**: `1password/load-secrets-action` が op CLI の version 未指定だったため、4 箇所すべてに `version: "2.34.0"` を pin（renovate アノテーション付き）。

## 変更内容

### create-github-app-token の権限を job ごとに最小化

| job | 用途 | 付与権限 |
|---|---|---|
| `create-draft-release` | release-please github-release | contents + pull-requests |
| `upload-assets` | `gh release upload`/`edit` のみ | contents のみ |
| `release-pr` | release-please release-pr | contents + pull-requests |
| `homebrew-update` | tap へ push + `gh pr create`/`merge` | contents + pull-requests |

`issues` は GitHub App (`nozomiishii-release`) に未付与のため付けない（要求すると release が 422 で落ちる）。

### op CLI version の pin

4 箇所の `1password/load-secrets-action` に `version: "2.34.0"` を追加。

## 検証

`zizmor --persona=auditor` で `release.yaml` に対し **No findings**（0 findings）を確認済み。
