### PR TITLE
chore: pin 1password/load-secrets-action to semver tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"
@@ -166,7 +166,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"
@@ -215,7 +215,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"


### PR DESCRIPTION
## 背景

[nozomiishii/renovate#626](https://github.com/nozomiishii/renovate/pull/626) で `helpers:pinGitHubActionDigestsToSemver` を導入したが、本 repo の `1password/load-secrets-action` は `# v4` のままで preset の semver pin enforce が効いていなかった。

`# v4` は movable major tag を指すため、upstream が `v4` を別 commit に force-push すると Renovate が中身検証なしに digest 差し替え PR を出す（[git-harvest#205](https://github.com/nozomiishii/git-harvest/pull/205) と同じ事象）。

## 変更内容

release.yaml の 4 箇所を v4.0.1 で固定:

- digest: `92467eb` → `3a12b0a`
- コメント: `# v4` → `# v4.0.1`

これで `helpers:pinGitHubActionDigestsToSemver` の `extractVersion` が効き、以降は semver tag のみが Renovate の追跡対象になる。

## テスト

CI に任せる。