### PR TITLE
feat: add required summary gate job to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,3 +80,15 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  required:
+    needs: [lint, build-and-test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1


### PR DESCRIPTION
## 概要

- CI ワークフローに `required` サマリーゲートジョブを追加
- `lint` と `build-and-test` の両方に依存し、いずれかが失敗またはキャンセルされた場合に失敗する
- Branch Protection の required status check を `required` ジョブ 1 つに集約できるようになる

## テスト計画

- [ ] CI が正常に通ることを確認
- [ ] `required` ジョブが `lint`, `build-and-test` の完了後に実行されることを確認

https://claude.ai/code/session_01WT3uDc26XFEw3aMy8rJgJ3