### PR TITLE
fix: add unique name to required gate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,8 @@ jobs:
         run: make test
 
   required:
+    # name 変更時は infra 側も更新する
+    name: CI / required
     needs: [lint, build-and-test]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
   required:
     needs: [lint, build-and-test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         run: make test
 
   required:
-    # name 変更時は infra 側も更新する
+    # name 変更時は infra 側の required_status_checks も更新する
     name: CI / required
     needs: [lint, build-and-test]
     if: always()


### PR DESCRIPTION
## 概要

- required ゲートジョブにユニークな name (`CI / required`) を付与
- 同名チェックコンテキストの衝突によるレースコンディションを防止

ruleset の `build-and-test` → `CI / required` 更新は PR マージ後に実施。

https://claude.ai/code/session_01TkQRPr4KydLk53utjxtLRJ