### PR TITLE
chore: move pull-request permission to job level for revert support

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -7,9 +7,10 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
+permissions: {}
 
 jobs:
   pull-request:
+    permissions:
+      pull-requests: write  # write: format revert PR titles, read: validate PR titles
     uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,8 @@ jobs:
         run: make test
 
   required:
+    # name 変更時は infra 側も更新する
+    name: CI / required
     needs: [lint, build-and-test]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
   required:
     needs: [lint, build-and-test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         run: make test
 
   required:
-    # name 変更時は infra 側も更新する
+    # name 変更時は infra 側の required_status_checks も更新する
     name: CI / required
     needs: [lint, build-and-test]
     if: always()


### PR DESCRIPTION
pull-request reusable workflow が revert PR タイトルの自動変換で pull-requests: write を必要とするようになったため、job レベルに permission を移動。関連: https://github.com/nozomiishii/workflows/pull/71