### PR TITLE
chore: trim readme-duplicated overview from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,5 @@
 # Repository Guidelines
 
-## プロジェクト概要
-
-Apple の 2018 年 Brooklyn イベントにインスパイアされた macOS スクリーンセーバー。[Pedro Carrasco のオリジナル](https://github.com/pedrommcarrasco/Brooklyn)を Swift 6 / macOS 26 (Tahoe) / Apple Silicon 向けにモダンに再実装したもの。75 個の MP4 アニメーションを `AVPlayerLayer` でループ再生する。
-
 ## Canvas での動作確認
 
 `.saver` をインストールせずにデバッグするには Canvas ターゲットを使う:


### PR DESCRIPTION
## 概要

/doctor 診断による常駐ガイドラインの trim。AGENTS.md の「プロジェクト概要」は README.md 冒頭とほぼ逐語一致のため削除する（est. 約 100 tokens/セッション削減）。

Canvas での動作確認・レイヤー構成・触る前に読む（壊しやすいポイント）は導出不能な情報のため残置。
