### PR TITLE
feat: add Developer ID signing and notarization to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,6 +108,13 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
           APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
+          # Developer ID 署名用の証明書 (.p12 を base64 化したもの) と公証用の
+          # App Store Connect API キー。作成手順は docs/release.md を参照。
+          APPLE_CERTIFICATE_P12: op://github-app/apple-codesign/certificate-p12
+          APPLE_P12_PASSWORD: op://github-app/apple-codesign/p12-password
+          ASC_KEY_ID: op://github-app/apple-codesign/asc-key-id
+          ASC_ISSUER_ID: op://github-app/apple-codesign/asc-issuer-id
+          ASC_PRIVATE_KEY: op://github-app/apple-codesign/asc-private-key
 
       - name: Generate GitHub App token
         id: app-token
@@ -132,6 +139,103 @@ jobs:
       - name: Run tests
         run: make test
 
+      # .p12 を一時キーチェーンに取り込む (詳細: docs/release.md)
+      # Apple 公式の CI 署名ツールが出たら置き換える:
+      # https://github.com/nozomiishii/Brooklyn/issues/140
+      - name: Import Developer ID certificate
+        env:
+          APPLE_CERTIFICATE_P12: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_P12 }}
+          APPLE_P12_PASSWORD: ${{ steps.secrets.outputs.APPLE_P12_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 16)"
+
+          echo -n "$APPLE_CERTIFICATE_P12" | base64 --decode -o "$CERT_PATH"
+
+          # 使い捨てのキーチェーンをマスターパスワード付きで作る
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # 自動ロックまでの時間を 6 時間にし、job 中のロックを防ぐ
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          # マスターパスワードでロックを解除する
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # 証明書 + 秘密鍵を .p12 から取り込む
+          security import "$CERT_PATH" \
+            -P "$APPLE_P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+
+          # 鍵の使用許可ダイアログの「常に許可」を先に押しておく相当の設定
+          security set-key-partition-list \
+            -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # codesign が鍵を探す検索対象にこのキーチェーンを載せる
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
+          rm "$CERT_PATH"
+
+      # Developer ID 署名。フラグは公証の必須要件 (詳細: docs/release.md)
+      - name: Sign .saver
+        run: |
+          # identity はキーチェーンに 1 つだけなので自動検出
+          IDENTITY=$(security find-identity -v -p codesigning "$RUNNER_TEMP/signing.keychain-db" \
+            | grep -o '"Developer ID Application: [^"]*"' | head -1 | tr -d '"')
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No Developer ID Application identity found in keychain"
+            exit 1
+          fi
+
+          # 秘密鍵でバンドルに署名し、証明書 (公開鍵) を同梱する
+          codesign --force --options runtime --timestamp \
+            --sign "$IDENTITY" \
+            build/Build/Products/Release/Brooklyn.saver
+
+          # 署名が壊れていないか再検証し、署名内容をログに残す
+          codesign --verify --strict --verbose=2 \
+            build/Build/Products/Release/Brooklyn.saver
+          codesign --display --verbose=2 \
+            build/Build/Products/Release/Brooklyn.saver
+
+      # Apple にスキャンさせ、公証チケットを .saver に staple する
+      - name: Notarize and staple
+        env:
+          ASC_KEY_ID: ${{ steps.secrets.outputs.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ steps.secrets.outputs.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ steps.secrets.outputs.ASC_PRIVATE_KEY }}
+        run: |
+          # 公証キー (.p8) をファイルに復元する
+          KEY_PATH="$RUNNER_TEMP/asc-key.p8"
+          printf '%s\n' "$ASC_PRIVATE_KEY" > "$KEY_PATH"
+
+          # 提出用に zip 梱包する
+          cd build/Build/Products/Release
+          ditto -c -k --keepParent Brooklyn.saver notarize.zip
+
+          # 公証キーで本人確認し、Apple の検査に提出して合格を待つ
+          SUBMIT_JSON=$(xcrun notarytool submit notarize.zip \
+            --key "$KEY_PATH" \
+            --key-id "$ASC_KEY_ID" \
+            --issuer "$ASC_ISSUER_ID" \
+            --wait --output-format json)
+          echo "$SUBMIT_JSON" | jq .
+
+          # 不合格なら検査ログを出力して fail する
+          STATUS=$(echo "$SUBMIT_JSON" | jq -r '.status')
+          if [ "$STATUS" != "Accepted" ]; then
+            SUBMISSION_ID=$(echo "$SUBMIT_JSON" | jq -r '.id')
+            echo "::error::Notarization failed with status: ${STATUS}"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$KEY_PATH" \
+              --key-id "$ASC_KEY_ID" \
+              --issuer "$ASC_ISSUER_ID"
+            exit 1
+          fi
+
+          # 合格チケットをバンドルに添付し、オフラインでも検証できるようにする
+          xcrun stapler staple Brooklyn.saver
+          xcrun stapler validate Brooklyn.saver
+
+          # 提出用 zip を削除する (配布物は後段の Package step で作り直す)
+          rm notarize.zip
+
       - name: Package .saver
         run: |
           cd build/Build/Products/Release
@@ -152,6 +256,13 @@ jobs:
         run: |
           gh release edit "${TAG_NAME}" \
             --draft=false
+
+      # runner は ephemeral だが、署名鍵は job 終了を待たず明示的に破棄する
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" || true
+          rm -f "$RUNNER_TEMP/certificate.p12" "$RUNNER_TEMP/asc-key.p8"
 
   # publish 後に次の release PR を作成/更新
   release-pr:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,13 +108,22 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
           APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
-          # Developer ID 署名用の証明書 (.p12 を base64 化したもの) と公証用の
-          # App Store Connect API キー。作成手順は docs/release.md を参照。
-          APPLE_CERTIFICATE_P12: op://github-app/apple-release/certificate-p12
-          APPLE_P12_PASSWORD: op://github-app/apple-release/p12-password
-          ASC_KEY_ID: op://github-app/apple-release/asc-key-id
-          ASC_ISSUER_ID: op://github-app/apple-release/asc-issuer-id
-          ASC_PRIVATE_KEY: op://github-app/apple-release/asc-private-key
+
+      # Apple の鍵は専用 vault + 専用 service account で読む。他リポジトリの
+      # CI が侵害されても署名鍵に届かないための分離 (詳細: docs/release.md)
+      - name: Load Apple secrets from 1Password
+        id: apple-secrets
+        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.38.1"
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APPLE }}
+          APPLE_CERTIFICATE_P12: op://apple-developer/developer-id/certificate-p12
+          APPLE_P12_PASSWORD: op://apple-developer/developer-id/p12-password
+          ASC_KEY_ID: op://apple-developer/app-store-connect/key-id
+          ASC_ISSUER_ID: op://apple-developer/app-store-connect/issuer-id
+          ASC_PRIVATE_KEY: op://apple-developer/app-store-connect/private-key
 
       - name: Generate GitHub App token
         id: app-token
@@ -144,8 +153,8 @@ jobs:
       # https://github.com/nozomiishii/Brooklyn/issues/140
       - name: Import Developer ID certificate
         env:
-          APPLE_CERTIFICATE_P12: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_P12 }}
-          APPLE_P12_PASSWORD: ${{ steps.secrets.outputs.APPLE_P12_PASSWORD }}
+          APPLE_CERTIFICATE_P12: ${{ steps.apple-secrets.outputs.APPLE_CERTIFICATE_P12 }}
+          APPLE_P12_PASSWORD: ${{ steps.apple-secrets.outputs.APPLE_P12_PASSWORD }}
         run: |
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
@@ -197,9 +206,9 @@ jobs:
       # Apple にスキャンさせ、公証チケットを .saver に staple する
       - name: Notarize and staple
         env:
-          ASC_KEY_ID: ${{ steps.secrets.outputs.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ steps.secrets.outputs.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY: ${{ steps.secrets.outputs.ASC_PRIVATE_KEY }}
+          ASC_KEY_ID: ${{ steps.apple-secrets.outputs.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ steps.apple-secrets.outputs.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ steps.apple-secrets.outputs.ASC_PRIVATE_KEY }}
         run: |
           # 公証キー (.p8) をファイルに復元する
           KEY_PATH="$RUNNER_TEMP/asc-key.p8"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,17 +108,9 @@ jobs:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
           APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
-
-      # Apple の鍵は専用 vault + 専用 service account で読む。他リポジトリの
-      # CI が侵害されても署名鍵に届かないための分離 (詳細: docs/release.md)
-      - name: Load Apple secrets from 1Password
-        id: apple-secrets
-        uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5.0.0
-        with:
-          # renovate: datasource=docker depName=1password/op versioning=semver
-          version: "2.38.1"
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_APPLE }}
+          # Apple の鍵は専用 vault。apple-developer vault を読めるのは Brooklyn の
+          # service account だけにし、他リポジトリの CI 侵害から署名鍵を隔離する
+          # (詳細: docs/release.md)
           APPLE_CERTIFICATE_P12: op://apple-developer/developer-id/certificate-p12
           APPLE_P12_PASSWORD: op://apple-developer/developer-id/p12-password
           ASC_KEY_ID: op://apple-developer/app-store-connect/key-id
@@ -153,8 +145,8 @@ jobs:
       # https://github.com/nozomiishii/Brooklyn/issues/140
       - name: Import Developer ID certificate
         env:
-          APPLE_CERTIFICATE_P12: ${{ steps.apple-secrets.outputs.APPLE_CERTIFICATE_P12 }}
-          APPLE_P12_PASSWORD: ${{ steps.apple-secrets.outputs.APPLE_P12_PASSWORD }}
+          APPLE_CERTIFICATE_P12: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_P12 }}
+          APPLE_P12_PASSWORD: ${{ steps.secrets.outputs.APPLE_P12_PASSWORD }}
         run: |
           CERT_PATH="$RUNNER_TEMP/certificate.p12"
           KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
@@ -206,9 +198,9 @@ jobs:
       # Apple にスキャンさせ、公証チケットを .saver に staple する
       - name: Notarize and staple
         env:
-          ASC_KEY_ID: ${{ steps.apple-secrets.outputs.ASC_KEY_ID }}
-          ASC_ISSUER_ID: ${{ steps.apple-secrets.outputs.ASC_ISSUER_ID }}
-          ASC_PRIVATE_KEY: ${{ steps.apple-secrets.outputs.ASC_PRIVATE_KEY }}
+          ASC_KEY_ID: ${{ steps.secrets.outputs.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ steps.secrets.outputs.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ steps.secrets.outputs.ASC_PRIVATE_KEY }}
         run: |
           # 公証キー (.p8) をファイルに復元する
           KEY_PATH="$RUNNER_TEMP/asc-key.p8"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,11 +110,11 @@ jobs:
           APP_PRIVATE_KEY: op://github-app/nozomiishii-release/credential
           # Developer ID 署名用の証明書 (.p12 を base64 化したもの) と公証用の
           # App Store Connect API キー。作成手順は docs/release.md を参照。
-          APPLE_CERTIFICATE_P12: op://github-app/apple-codesign/certificate-p12
-          APPLE_P12_PASSWORD: op://github-app/apple-codesign/p12-password
-          ASC_KEY_ID: op://github-app/apple-codesign/asc-key-id
-          ASC_ISSUER_ID: op://github-app/apple-codesign/asc-issuer-id
-          ASC_PRIVATE_KEY: op://github-app/apple-codesign/asc-private-key
+          APPLE_CERTIFICATE_P12: op://github-app/apple-release/certificate-p12
+          APPLE_P12_PASSWORD: op://github-app/apple-release/p12-password
+          ASC_KEY_ID: op://github-app/apple-release/asc-key-id
+          ASC_ISSUER_ID: op://github-app/apple-release/asc-issuer-id
+          ASC_PRIVATE_KEY: op://github-app/apple-release/asc-private-key
 
       - name: Generate GitHub App token
         id: app-token

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,9 +44,10 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 
 ### 1Password vault `apple-developer`
 
-Apple の鍵は共有の `github-app` vault ではなく専用 vault に置き、専用 service account で読む。他リポジトリの CI が侵害されても署名鍵に届かないための分離。vault の切り方は「同じ場所に配る鍵は同じ vault」を基準にする。
+Apple の鍵は共有の `github-app` vault ではなく専用 vault に置く。vault の切り方は「同じ場所に配る鍵は同じ vault」を基準にする。
 
-- 専用 service account のトークンは Brooklyn の Actions secret `OP_SERVICE_ACCOUNT_TOKEN_APPLE` にのみ配布する。配布先を増やす基準は「その repo が Apple 署名を実際に行うか」
+- service account は repo ごとに 1 つ (Brooklyn 用は「Brooklyn」)。`apple-developer` vault を読めるのは Brooklyn の service account だけにし、他リポジトリの CI が侵害されても署名鍵に届かないようにする
+- 1Password の service account は作成後に vault の追加・権限変更ができない ([公式](https://www.1password.dev/service-accounts/manage-service-accounts/))。アクセスする vault を増やすときは service account を作り直し、`OP_SERVICE_ACCOUNT_TOKEN` の値を新トークンに差し替える
 - 鍵が漏れた・漏れた疑いがある場合は、この vault の全アイテムをローテーションする
 
 | item | フィールド | 内容 |

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,9 +15,50 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 `release.yaml` は `main` への push / `workflow_dispatch` で起動し、以下 4 ジョブで構成される。
 
 1. **`create-draft-release`** (ubuntu): release-please が conventional commits を集計し、release PR が既にマージされていれば draft release + tag を作成。`release_created` と `tag_name` を outputs として返す
-2. **`upload-assets`** (macos-26, `release_created == 'true'` のみ): XcodeGen + `make build` + `make test` で `.saver` をビルドし、`.saver.zip` を GitHub Release に upload 後 publish
+2. **`upload-assets`** (macos-26, `release_created == 'true'` のみ): XcodeGen + `make build` + `make test` で `.saver` をビルドし、Developer ID 署名 + 公証 + staple を経て `.saver.zip` を GitHub Release に upload 後 publish（詳細は後述「署名と公証」）
 3. **`homebrew-update`** (macos-26, `release_created == 'true'` のみ): `brew bump-cask-pr` で `nozomiishii/homebrew-tap` の `Casks/brooklyn.rb` を新バージョンに更新する PR を作成し、出力から PR URL を捕捉して `gh pr merge --auto --squash` で auto-merge を有効化
 4. **`release-pr`** (ubuntu, `upload-assets` 失敗時を除き常時): release-please で次の release PR を作成 / 更新
+
+## 署名と公証
+
+`upload-assets` はビルド後に次の順で配布物を仕上げる。ローカルビルド (`make build` / `make install`) は ad-hoc 署名のままで、この処理はリリース CI だけで行う。
+
+- `.p12` を一時キーチェーンへ import（job 末尾の cleanup step で削除）
+- `codesign --force --options runtime --timestamp` で `Brooklyn.saver` に Developer ID 署名
+- `ditto` で zip 化して `notarytool submit --wait` で公証。`Accepted` 以外なら `notarytool log` を出力して fail
+- `stapler staple` でチケットをバンドルに貼付し、staple 済みバンドルを配布用 zip に固め直す
+
+補足:
+
+- `--options runtime`（hardened runtime）と `--timestamp` は公証の必須要件
+- `Brooklyn.saver` は framework を embed していないため、バンドル 1 回の codesign で完結する（ネスト署名は不要）
+- 署名 identity は一時キーチェーンから自動検出する。1Password に identity 文字列は持たない
+- 提出用 zip は使い捨てで、配布物は Package step が staple 済みバンドルから作り直す
+
+キーチェーン import は [GitHub 公式手順](https://docs.github.com/ja/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications)に準拠。公式手順との相違点:
+
+- キーチェーンパスワードは secret にせず `openssl rand` で実行ごとに生成する。job の中でしか使わない値なので、長命の secret を増やさない
+- provisioning profile の step はない。Developer ID 直接配布では使わない
+- `.p12` ファイルは import 直後に削除する
+- cleanup は公式手順だと self-hosted runner のみ必要とされるが、防御的に常に実行する
+
+### 1Password item `op://github-app/apple-codesign`
+
+release workflow が参照するフィールド。既存の service account (`OP_SERVICE_ACCOUNT_TOKEN`) がアクセスできる vault に置く。
+
+| フィールド | 内容 |
+| --- | --- |
+| `certificate-p12` | Developer ID Application 証明書 + 秘密鍵の .p12 を base64 化した文字列 |
+| `p12-password` | .p12 エクスポート時に設定したパスワード |
+| `asc-key-id` | App Store Connect API キーの Key ID |
+| `asc-issuer-id` | App Store Connect API の Issuer ID |
+| `asc-private-key` | API キー .p8 の中身（PEM テキスト） |
+
+### 鍵の更新
+
+- Developer ID Application 証明書は有効期限 5 年。期限が切れたら Xcode → Settings → Accounts → Manage Certificates で作り直し、Keychain Access から .p12 を書き出して `certificate-p12` / `p12-password` を更新する。署名 identity は workflow がキーチェーンから自動検出するため identity 文字列の登録は不要
+- 公証済みの配布物は証明書が失効しても有効なまま（staple されたチケットで検証される）
+- App Store Connect API キーに期限はないが、revoke したら `asc-key-id` / `asc-private-key` を差し替える
 
 ## Homebrew Cask 更新の実装方針
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,7 +42,7 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 - `.p12` ファイルは import 直後に削除する
 - cleanup は公式手順だと self-hosted runner のみ必要とされるが、防御的に常に実行する
 
-### 1Password item `op://github-app/apple-codesign`
+### 1Password item `op://github-app/apple-release`
 
 release workflow が参照するフィールド。既存の service account (`OP_SERVICE_ACCOUNT_TOKEN`) がアクセスできる vault に置く。
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -42,23 +42,26 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 - `.p12` ファイルは import 直後に削除する
 - cleanup は公式手順だと self-hosted runner のみ必要とされるが、防御的に常に実行する
 
-### 1Password item `op://github-app/apple-release`
+### 1Password vault `apple-developer`
 
-release workflow が参照するフィールド。既存の service account (`OP_SERVICE_ACCOUNT_TOKEN`) がアクセスできる vault に置く。
+Apple の鍵は共有の `github-app` vault ではなく専用 vault に置き、専用 service account で読む。他リポジトリの CI が侵害されても署名鍵に届かないための分離。vault の切り方は「同じ場所に配る鍵は同じ vault」を基準にする。
 
-| フィールド | 内容 |
-| --- | --- |
-| `certificate-p12` | Developer ID Application 証明書 + 秘密鍵の .p12 を base64 化した文字列 |
-| `p12-password` | .p12 エクスポート時に設定したパスワード |
-| `asc-key-id` | App Store Connect API キーの Key ID |
-| `asc-issuer-id` | App Store Connect API の Issuer ID |
-| `asc-private-key` | API キー .p8 の中身（PEM テキスト） |
+- 専用 service account のトークンは Brooklyn の Actions secret `OP_SERVICE_ACCOUNT_TOKEN_APPLE` にのみ配布する。配布先を増やす基準は「その repo が Apple 署名を実際に行うか」
+- 鍵が漏れた・漏れた疑いがある場合は、この vault の全アイテムをローテーションする
+
+| item | フィールド | 内容 |
+| --- | --- | --- |
+| `developer-id` | `certificate-p12` | Developer ID Application 証明書 + 秘密鍵の .p12 を base64 化した文字列 |
+| `developer-id` | `p12-password` | .p12 エクスポート時に設定したパスワード |
+| `app-store-connect` | `key-id` | App Store Connect API キーの Key ID |
+| `app-store-connect` | `issuer-id` | App Store Connect API の Issuer ID |
+| `app-store-connect` | `private-key` | API キー .p8 の中身（PEM テキスト） |
 
 ### 鍵の更新
 
 - Developer ID Application 証明書は有効期限 5 年。期限が切れたら Xcode → Settings → Accounts → Manage Certificates で作り直し、Keychain Access から .p12 を書き出して `certificate-p12` / `p12-password` を更新する。署名 identity は workflow がキーチェーンから自動検出するため identity 文字列の登録は不要
 - 公証済みの配布物は証明書が失効しても有効なまま（staple されたチケットで検証される）
-- App Store Connect API キーに期限はないが、revoke したら `asc-key-id` / `asc-private-key` を差し替える
+- App Store Connect API キーに期限はないが、revoke したら `app-store-connect` item の `key-id` / `private-key` を差し替える
 
 ## Homebrew Cask 更新の実装方針
 


### PR DESCRIPTION
## 概要

Apple Developer Program 登録に伴い、リリース CI に Developer ID 署名 + 公証 (notarization) + staple を実装する。

現状の配布物は未署名で、Homebrew Cask 側が quarantine 削除 + ad-hoc 再署名の postflight で Gatekeeper を回避している。本 PR 以降のリリースは署名 + 公証済みになり、ユーザーの Mac で警告なしにインストールできる。

## 変更内容

### .github/workflows/release.yaml (upload-assets ジョブ)

ビルド・テスト後、パッケージ前に以下の step を追加。

- Import Developer ID certificate: 1Password から取得した .p12 を一時キーチェーンへ取り込む
- Sign .saver: identity をキーチェーンから自動検出し、hardened runtime + secure timestamp 付きで署名 + 検証
- Notarize and staple: App Store Connect API キーで notarytool に提出し、合格チケットをバンドルに staple
- Clean up signing keychain: `if: always()` で鍵の痕跡を破棄

キーチェーン import は [GitHub 公式手順](https://docs.github.com/ja/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications)準拠。相違点 (キーチェーンパスワードの乱数生成など) は docs/release.md に記載。

### docs/release.md

署名と公証の節を追加。フローの補足、1Password item `op://github-app/apple-codesign` のフィールド定義、鍵の更新手順を記載。

## マージ前に必要な準備

release workflow が参照する 1Password item がまだ存在しない。以下を作成するまで、リリース時に upload-assets が失敗する (マージ自体は安全)。

- Developer ID Application 証明書を作成し .p12 を書き出す
- App Store Connect API キー (ロール: Developer) を作成する
- `github-app` vault に `apple-codesign` item を作成する (フィールド定義は docs/release.md 参照)

## 関連

- 追跡 Issue: #140 (Apple 公式の CI 署名ツールが出たら置き換える)
- フォローアップ (別リポジトリ): 署名付きリリースが 1 回成功したら、homebrew-tap の Casks/brooklyn.rb から quarantine 削除 + ad-hoc 再署名の postflight を撤去する

## 検証

- YAML 構文チェック済み
- 実地検証はマージ後の初回リリースで実施: `gh release download` → `codesign --verify --strict` / `xcrun stapler validate` / `spctl --assess` を確認する
