### PR TITLE
fix: store ASC private key as base64 in 1Password

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,9 +202,10 @@ jobs:
           ASC_ISSUER_ID: ${{ steps.secrets.outputs.ASC_ISSUER_ID }}
           ASC_PRIVATE_KEY: ${{ steps.secrets.outputs.ASC_PRIVATE_KEY }}
         run: |
-          # 公証キー (.p8) をファイルに復元する
+          # 公証キー (.p8) を base64 から復元する (PEM の改行が
+          # フィールド経由で失われるのを防ぐため base64 で保存している)
           KEY_PATH="$RUNNER_TEMP/asc-key.p8"
-          printf '%s\n' "$ASC_PRIVATE_KEY" > "$KEY_PATH"
+          echo -n "$ASC_PRIVATE_KEY" | base64 --decode -o "$KEY_PATH"
 
           # 提出用に zip 梱包する
           cd build/Build/Products/Release

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,7 +56,7 @@ Apple の鍵は共有の `nozomiishii-release` vault ではなく専用 vault �
 | `developer-id` | `p12-password` | .p12 エクスポート時に設定したパスワード |
 | `app-store-connect` | `key-id` | App Store Connect API キーの Key ID |
 | `app-store-connect` | `issuer-id` | App Store Connect API の Issuer ID |
-| `app-store-connect` | `private-key` | API キー .p8 の中身（PEM テキスト） |
+| `app-store-connect` | `private-key` | API キー .p8 を base64 化した文字列（改行を含む PEM をフィールドで壊さず保持するため） |
 
 ### 鍵の更新
 


### PR DESCRIPTION
## 概要

初回署名リリース (v0.1.26) の upload-assets が公証提出で `Error: invalidPEMDocument` により失敗した。

原因: 複数行の PEM (`.p8`) が 1Password フィールド経由で改行を失い、notarytool が読めない形になっていた。

## 変更内容

- `.p8` を `.p12` と同じく base64 文字列として保存し、workflow 側で `base64 --decode` して復元する
- docs/release.md のフィールド定義を更新

## マージ後に必要な作業

- 1Password `apple-developer/app-store-connect/private-key` の値を base64 化した文字列に差し替える (手順は本 PR のセッションで案内済み)
- マージ後の Release run が draft release v0.1.26 を検出して署名フローを再実行する