### PR TITLE
chore: align docs style with doc skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,13 @@ make generate && open Brooklyn.xcodeproj
 
 ## アーキテクチャ
 
-### ターゲット構成（project.yaml で定義）
+### ターゲット構成
 
-- **Brooklyn** — `.saver` バンドル。`NSPrincipalClass: Brooklyn.BrooklynView` でシステムに登録
-- **Canvas** — デバッグ用 macOS アプリ。Brooklyn と同じソースをビルドし、ウィンドウ内でスクリーンセーバーを表示
-- **BrooklynTests** — ユニットテスト。ソースを直接含めてテスト
+project.yaml で定義する。
+
+- Brooklyn — `.saver` バンドル。`NSPrincipalClass: Brooklyn.BrooklynView` でシステムに登録
+- Canvas — デバッグ用 macOS アプリ。Brooklyn と同じソースをビルドし、ウィンドウ内でスクリーンセーバーを表示
+- BrooklynTests — ユニットテスト。ソースを直接含めてテスト
 
 ### レイヤー構成
 
@@ -29,12 +31,16 @@ BrooklynView (ScreenSaverView)
         └── ConfigureSheetController (NSWindowController ブリッジ)
 ```
 
-## 触る前に読む（壊しやすいポイント）
+## 触る前に読む
 
-### macOS Sonoma+ バグ回避（変更時はテストで regression を確認）
+壊しやすいポイント。
+
+### macOS Sonoma+ バグ回避
+
+変更時はテストで regression を確認する。
 
 - `stopAnimation()` が呼ばれない → `com.apple.screensaver.willstop` 通知で cleanup
-- `isPreview` が常に true → フレームサイズで判定（< 400×300 = プレビュー）
+- `isPreview` が常に true → フレームサイズで判定し、幅 < 400 または高さ < 300 をプレビューと見なす
 - `AVQueuePlayer` が 1 アイテムで停止 → `LoopPlayer` が自動複製
 
 ### Swift 6 Strict Concurrency

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,9 @@ CLAUDE.md の「アーキテクチャ」「ハードルール」節の補足。�
 
 ## 再生ロジック (`BrooklynManager.makePlayerItems`)
 
-### Customize OFF（デフォルト）
+### Customize OFF
 
-全 75 アニメーション使用。`original` を先頭に 1 回再生 → 残りをランダムシャッフル → `LoopPlayer` が各アイテムを末尾にコピーして無限ループ。
+デフォルトの動作。全 75 アニメーション使用。`original` を先頭に 1 回再生 → 残りをランダムシャッフル → `LoopPlayer` が各アイテムを末尾にコピーして無限ループ。
 
 ### Customize ON
 
@@ -22,25 +22,22 @@ CLAUDE.md の「アーキテクチャ」「ハードルール」節の補足。�
 
 ## macOS Sonoma+ バグ回避
 
-`BrooklynView` に実装済み。**変更時はテストで regression を確認すること。** 各回避策の症状と根本原因:
+`BrooklynView` に実装済み。変更時はテストで regression を確認すること。各回避策の症状と根本原因:
 
 ### `stopAnimation()` が呼ばれない
 
-**症状**: macOS Sonoma 以降、`ScreenSaverView.stopAnimation()` がライフサイクル終了時に呼ばれず、`AVPlayer` がメモリに残り続ける（screensaver プロセスが生き残るとリソースリーク）。
-
-**回避策**: `com.apple.screensaver.willstop` 通知を購読し、コールバック内で `AVPlayerLayer` の解放と `LoopPlayer` の停止を実行する。
+- 症状: macOS Sonoma 以降、`ScreenSaverView.stopAnimation()` がライフサイクル終了時に呼ばれず、`AVPlayer` がメモリに残り続ける。screensaver プロセスが生き残るとリソースリークになる
+- 回避策: `com.apple.screensaver.willstop` 通知を購読し、コールバック内で `AVPlayerLayer` の解放と `LoopPlayer` の停止を実行する
 
 ### `isPreview` が常に true
 
-**症状**: System Settings のプレビュー外（実際のスクリーンセーバー起動時）でも `ScreenSaverView.isPreview` が `true` を返す。プレビュー判定ロジックを `isPreview` に依存すると、本番再生でもプレビュー用パスを実行してしまう。
-
-**回避策**: フレームサイズで判定する（**幅 < 400 または 高さ < 300 をプレビューと見なす**）。System Settings のプレビューウィンドウサイズを基準にした閾値。
+- 症状: System Settings のプレビュー外、実際のスクリーンセーバー起動時でも `ScreenSaverView.isPreview` が `true` を返す。プレビュー判定ロジックを `isPreview` に依存すると、本番再生でもプレビュー用パスを実行してしまう
+- 回避策: フレームサイズで判定し、幅 < 400 または高さ < 300 をプレビューと見なす。System Settings のプレビューウィンドウサイズを基準にした閾値
 
 ### `AVQueuePlayer` が 1 アイテムで停止
 
-**症状**: `AVQueuePlayer` がキューを使い切った後、デフォルトではループしない（最後のアイテム再生後に停止）。
-
-**回避策**: `LoopPlayer` クラスが `AVPlayerItemDidPlayToEndTimeNotification` を監視し、終了したアイテムをキュー末尾に再追加する。これにより無限ループを実現。
+- 症状: `AVQueuePlayer` がキューを使い切った後、デフォルトではループせず、最後のアイテム再生後に停止する
+- 回避策: `LoopPlayer` クラスが `AVPlayerItemDidPlayToEndTimeNotification` を監視し、終了したアイテムをキュー末尾に再追加して無限ループを実現する
 
 ## Swift 6 Strict Concurrency
 
@@ -54,8 +51,8 @@ UI / 設定に直接触るため MainActor で隔離。
 
 ### `NotificationCenter` オブザーバー
 
-`nonisolated(unsafe)` プロパティで保持する。理由: `NSObjectProtocol` トークン自体は thread-safe で actor isolation を要求しないため、わざわざ `@MainActor` で囲む必要がない（むしろデイニシャライザで解放する際に actor 制約が邪魔になる）。
+`nonisolated(unsafe)` プロパティで保持する。理由: `NSObjectProtocol` トークン自体は thread-safe で actor isolation を要求しないため、わざわざ `@MainActor` で囲む必要がない。むしろデイニシャライザで解放する際に actor 制約が邪魔になる。
 
 ### 通知コールバックから `@MainActor` メソッドを呼ぶ
 
-`MainActor.assumeIsolated { ... }` を使用する。`com.apple.screensaver.*` 通知は MainActor 上でディスパッチされる契約のため、`Task { @MainActor in ... }` で async コンテキストを作る必要はない（同期的に MainActor を assume すれば足りる）。
+`MainActor.assumeIsolated { ... }` を使用する。`com.apple.screensaver.*` 通知は MainActor 上でディスパッチされる契約のため、`Task { @MainActor in ... }` で async コンテキストを作る必要はない。同期的に MainActor を assume すれば足りる。

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,16 +14,16 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 
 `release.yaml` は `main` への push / `workflow_dispatch` で起動し、以下 4 ジョブで構成される。
 
-1. **`create-draft-release`** (ubuntu): release-please が conventional commits を集計し、release PR が既にマージされていれば draft release + tag を作成。`release_created` と `tag_name` を outputs として返す
-2. **`upload-assets`** (macos-26, `release_created == 'true'` のみ): XcodeGen + `make build` + `make test` で `.saver` をビルドし、Developer ID 署名 + 公証 + staple を経て `.saver.zip` を GitHub Release に upload 後 publish（詳細は後述「署名と公証」）
-3. **`homebrew-update`** (macos-26, `release_created == 'true'` のみ): `brew bump-cask-pr` で `nozomiishii/homebrew-tap` の `Casks/brooklyn.rb` を新バージョンに更新する PR を作成し、出力から PR URL を捕捉して `gh pr merge --auto --squash` で auto-merge を有効化
-4. **`release-pr`** (ubuntu, `upload-assets` 失敗時を除き常時): release-please で次の release PR を作成 / 更新
+- `create-draft-release` (ubuntu): release-please が conventional commits を集計し、release PR が既にマージされていれば draft release + tag を作成。`release_created` と `tag_name` を outputs として返す
+- `upload-assets` (macos-26, `release_created == 'true'` のみ): XcodeGen + `make build` + `make test` で `.saver` をビルドし、Developer ID 署名 + 公証 + staple を経て `.saver.zip` を GitHub Release に upload 後 publish。詳細は「署名と公証」節
+- `homebrew-update` (macos-26, `release_created == 'true'` のみ): `brew bump-cask-pr` で `nozomiishii/homebrew-tap` の `Casks/brooklyn.rb` を新バージョンに更新する PR を作成し、出力から PR URL を捕捉して `gh pr merge --auto --squash` で auto-merge を有効化
+- `release-pr` (ubuntu, `upload-assets` 失敗時を除き常時): release-please で次の release PR を作成 / 更新
 
 ## 署名と公証
 
 `upload-assets` はビルド後に次の順で配布物を仕上げる。ローカルビルド (`make build` / `make install`) は ad-hoc 署名のままで、この処理はリリース CI だけで行う。
 
-- `.p12` を一時キーチェーンへ import（job 末尾の cleanup step で削除）
+- `.p12` を一時キーチェーンへ import。job 末尾の cleanup step で削除する
 - `codesign --force --options runtime --timestamp` で `Brooklyn.saver` に Developer ID 署名
 - `ditto` で zip 化して `notarytool submit --wait` で公証。`Accepted` 以外なら `notarytool log` を出力して fail
 - `stapler staple` でチケットをバンドルに貼付し、staple 済みバンドルを配布用 zip に固め直す
@@ -31,7 +31,7 @@ CLAUDE.md の「CI / リリース」節の補足。`release.yaml` / `.github/wor
 補足:
 
 - `--options runtime`（hardened runtime）と `--timestamp` は公証の必須要件
-- `Brooklyn.saver` は framework を embed していないため、バンドル 1 回の codesign で完結する（ネスト署名は不要）
+- `Brooklyn.saver` は framework を embed していないため、バンドル 1 回の codesign で完結する。ネスト署名は不要
 - 署名 identity は一時キーチェーンから自動検出する。1Password に identity 文字列は持たない
 - 提出用 zip は使い捨てで、配布物は Package step が staple 済みバンドルから作り直す
 
@@ -56,27 +56,27 @@ Apple の鍵は共有の `nozomiishii-release` vault ではなく専用 vault �
 | `developer-id` | `p12-password` | .p12 エクスポート時に設定したパスワード |
 | `app-store-connect` | `key-id` | App Store Connect API キーの Key ID |
 | `app-store-connect` | `issuer-id` | App Store Connect API の Issuer ID |
-| `app-store-connect` | `private-key` | API キー .p8 を base64 化した文字列（改行を含む PEM をフィールドで壊さず保持するため） |
+| `app-store-connect` | `private-key` | API キー .p8 を base64 化した文字列。改行を含む PEM をフィールドで壊さず保持するため |
 
 ### 鍵の更新
 
 - Developer ID Application 証明書は有効期限 5 年。期限が切れたら Xcode → Settings → Accounts → Manage Certificates で作り直し、Keychain Access から .p12 を書き出して `certificate-p12` / `p12-password` を更新する。署名 identity は workflow がキーチェーンから自動検出するため identity 文字列の登録は不要
-- 公証済みの配布物は証明書が失効しても有効なまま（staple されたチケットで検証される）
+- 公証済みの配布物は証明書が失効しても有効なまま。staple されたチケットで検証される
 - App Store Connect API キーに期限はないが、revoke したら `app-store-connect` item の `key-id` / `private-key` を差し替える
 
 ## Homebrew Cask 更新の実装方針
 
-`homebrew-update` は **Homebrew 公式 CLI `brew bump-cask-pr` を直接呼ぶ** 実装。検討した代替案を採用しなかった理由:
+`homebrew-update` は Homebrew 公式 CLI `brew bump-cask-pr` を直接呼ぶ実装。検討した代替案を採用しなかった理由:
 
-### Renovate に任せる（不採用）
+### 不採用: Renovate に任せる
 
-`homebrew` manager は **Formula のみ対応**で Cask 未サポート（[renovate#32965](https://github.com/renovatebot/renovate/discussions/32965) が open のまま、コメント 0）。`postUpgradeTasks` で sha256 を再計算する手は Mend Cloud では使えない。
+`homebrew` manager は Formula のみ対応で Cask 未サポート。[renovate#32965](https://github.com/renovatebot/renovate/discussions/32965) が open のまま、コメント 0。`postUpgradeTasks` で sha256 を再計算する手は Mend Cloud では使えない。
 
-### `mislav/bump-homebrew-formula-action`（不採用）
+### 不採用: `mislav/bump-homebrew-formula-action`
 
-`homebrew-tap` の `main` が GitHub Rulesets で保護されていると、`branchRes.data.protected === true` 判定で `update-<file>-<timestamp>` という別ブランチに commit を作る経路に入り、`create-pullrequest: false` のままだと PR 化もマージもされず孤立ブランチが残る。ジョブは "success" で終わるためサイレント失敗（実例: `update-git-harvest.rb-1777372050` が放置されていた）。
+`homebrew-tap` の `main` が GitHub Rulesets で保護されていると、`branchRes.data.protected === true` 判定で `update-<file>-<timestamp>` という別ブランチに commit を作る経路に入り、`create-pullrequest: false` のままだと PR 化もマージもされず孤立ブランチが残る。ジョブは "success" で終わるためサイレント失敗になる。実例: `update-git-harvest.rb-1777372050` が放置されていた。
 
-### 手書き `git push` + `gh pr create`（不採用）
+### 不採用: 手書き `git push` + `gh pr create`
 
 動くが Homebrew エコシステム非標準。本流は公式 [Autobump](https://docs.brew.sh/Autobump) でも使われている `brew bump-cask-pr` / `brew bump --casks`。
 
@@ -84,12 +84,12 @@ Apple の鍵は共有の `nozomiishii-release` vault ではなく専用 vault �
 
 - 新版 tarball を取得して `sha256` を自動再計算
 - `Casks/brooklyn.rb` のフィールド単位更新
-- API 経由で commit + PR 作成（重複 PR 検出も内蔵）
+- API 経由で commit + PR 作成。重複 PR 検出も内蔵
 - `brew style` での文法検証
 
 ## runner 選定
 
-`homebrew-update` は **macos-26** で動かす（`upload-assets` と統一）。Linux runner + `Homebrew/actions/setup-homebrew` も試したが、`Homebrew/actions` が monorepo で個別 tag を持たないため zizmor の `stale-action-refs` ルールに引っかかり、commit pin しても警告が出続ける。macOS runner なら `brew` がプリインストールされているので setup ステップごと不要になる。
+`homebrew-update` は macos-26 で動かし、runner を `upload-assets` と統一する。Linux runner + `Homebrew/actions/setup-homebrew` も試したが、`Homebrew/actions` が monorepo で個別 tag を持たないため zizmor の `stale-action-refs` ルールに引っかかり、commit pin しても警告が出続ける。macOS runner なら `brew` がプリインストールされているので setup ステップごと不要になる。
 
 ## 周辺前提
 


### PR DESCRIPTION
## 概要

docs/ 配下と AGENTS.md を /doc スキルの文章ガイドラインに合わせてスタイル修正する。内容 (事実) は変えず、装飾・文体のみの修正。

## 変更点

- 太字を除去し、強調は見出し・箇条書きの構造で示す
  - architecture.md の「症状 / 回避策」ラベルは箇条書きに置き換え
  - release.md の「（不採用）」見出しは「不採用: 〜」形式に統一 (既存の「採用: 〜」と対になる)
- release.md のジョブ構成の番号付きリストを箇条書きに変更 (並び替えに弱いため)
- 丸括弧の補足を文に開く (用語の言い換え注釈と runner 指定の括弧は可読性を優先して維持)
- AGENTS.md の見出し内括弧を本文に移動 (CLAUDE.md は symlink のため追従)

## 経緯

署名・公証の節を追加する #141 とのコンフリクトを避けるため、マージ後の main を base に作業した。