### PR TITLE
chore: release 1.0.0 via release-as

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "0e72eef93fe5e3acdf957e3be59c8301e3b961c2",
+  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
## 概要

初の署名 + 公証付き配布 (v0.1.26) が完成したのを機に、バージョンを 1.0.0 に上げる。

## 方法

squash マージ (本文 BLANK 設定) では `Release-As:` コミットフッターが消えるため、release-please 設定の `release-as` で指定する。

## マージ後の流れ

1. release-pr ジョブが release PR「chore: release 1.0.0」を作成/更新する
2. その release PR をマージすると v1.0.0 が署名 + 公証付きでリリースされる
3. リリース後、`release-as` を外すフォローアップ PR を出す (残すと以後のリリースが 1.0.0 に固定されるため)