### PR TITLE
chore: remove release-as after v1.0.0

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "0e72eef93fe5e3acdf957e3be59c8301e3b961c2",
-  "release-as": "1.0.0",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
## 概要

v1.0.0 リリース完了に伴い、[#146](https://github.com/nozomiishii/Brooklyn/pull/146) で一時的に入れた `release-as` を外す。残すと以後の全リリースが 1.0.0 に固定されるため。

以後は conventional commits による通常の自動バージョニングに戻る (1.0.0 到達により pre-major 用の bump フラグは実質無効になり、feat = minor / fix = patch)。